### PR TITLE
Attempt to fix syntax error

### DIFF
--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -20,7 +20,7 @@ defmodule Slack.State do
   """
   defstruct socket: nil, channels: nil, me: nil, users: nil
   @type state :: %__MODULE__{
-    socket: :websocket_client.Req,
+    socket: :websocket_req,
     channels: pid,
     me: Map,
     users: pid


### PR DESCRIPTION
I'm not sure this is correct, but it compiles now at least. I was getting 
```
atom cannot be followed by an alias. If the '.' was meant to be part of the atom's name, the name must be quoted. Syntax error before: '.'
```