### PR TITLE
Fixes State not persisting

### DIFF
--- a/lib/slack/socket.ex
+++ b/lib/slack/socket.ex
@@ -21,7 +21,7 @@ defmodule Slack.Socket do
     if Map.has_key?(json, :type) do
       {:ok, new_state} = send_handler_message(json, state)
 
-      state = Map.put(state, :handler_state, new_state)
+      state = Map.put(state, :module_state, new_state)
     end
 
     {:ok, state}

--- a/test/slack/socket_test.exs
+++ b/test/slack/socket_test.exs
@@ -44,7 +44,7 @@ defmodule Slack.SocketTest do
 
     {:ok, result} = Slack.Socket.websocket_handle({:text, message}, "foo", state)
 
-    assert result.handler_state == ["bar"]
+    assert result.module_state == ["bar"]
   end
 
   test "it returns existing state if called without type" do


### PR DESCRIPTION
This fixes #2. Was there a variable name change from handler_state to module_state? I have tested this in a live slack implementation and it works for me.