### PR TITLE
Fix discrepancy in README vs mix.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 def deps do
   [{:slack, "~> 0.2.0"},
-   {:websocket_client, git: "https://github.com/jeremyong/websocket_client"}]
+   {:websocket_client, github: "jeremyong/websocket_client"}]
 end
 ```
 


### PR DESCRIPTION
Our `mix.exs` has the dep `{:websocket_client, github: "jeremyong/websocket_client"}`. Our README suggests you add `{:websocket_client, github: "https://github.com/jeremyong/websocket_client"}` to your own deps.

This actually throws off `mix deps.get`: the github version appends an extra `.git`, giving the error:

```
Unchecked dependencies for environment dev:
* websocket_client (https://github.com/jeremyong/websocket_client)
  the dependency websocket_client in mix.exs is overriding a child dependency:

  > In mix.exs:
    {:websocket_client, nil, [git: "https://github.com/jeremyong/websocket_client"]}

  > In deps/slack/mix.exs:
    {:websocket_client, nil, [git: "git://github.com/jeremyong/websocket_client.git"]}

  Ensure they match or specify one of the above in your Rex.Mixfile deps and set `override: true`
** (Mix) Can't continue due to errors on dependencies
```

This modifies the README to normalize the two, although I'm not sure if our users even need to specify the dependency at all.