### PR TITLE
Allow clients to send pings

### DIFF
--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -20,18 +20,28 @@ defmodule SlackTest do
   end
 
   test "send_raw sends slack formatted to client" do
-    result = Slack.send_raw(~s/{"text": "foo"}/, %{socket: nil}, FakeWebsocketClient)
+    result = Slack.send_raw(~s/{"text": "foo"}/, %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"text": "foo"}/, nil}
   end
 
   test "send_message sends message formatted to client" do
-    result = Slack.send_message("hello", "channel", %{socket: nil}, FakeWebsocketClient)
+    result = Slack.send_message("hello", "channel", %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
   end
 
   test "indicate_typing sends typing notification to client" do
-    result = Slack.indicate_typing("channel", %{socket: nil}, FakeWebsocketClient)
+    result = Slack.indicate_typing("channel", %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"channel":"channel","type":"typing"}/, nil}
+  end
+
+  test "send_ping sends ping to client" do
+    result = Slack.send_ping(%{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"type":"ping"}/, nil}
+  end
+
+  test "send_ping with data sends ping + data to client" do
+    result = Slack.send_ping([foo: :bar], %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"foo":"bar","type":"ping"}/, nil}
   end
 
   test "init formats rtm results properly" do
@@ -44,7 +54,7 @@ defmodule SlackTest do
       users: [%{id: "123"}],
     }
 
-    {:ok, %{slack: slack, state: state}} = Bot.init(%{rtm: rtm, state: 1}, nil)
+    {:ok, %{slack: slack, state: state}} = Bot.init(%{rtm: rtm, state: 1, client: FakeWebsocketClient}, nil)
 
     assert slack.me.name == "fake"
     assert slack.team.name == "Foo"


### PR DESCRIPTION
This commit enables `Slack.send_ping`, which can be handled via the existing `Slack.handle_message`.

It's more involved than it ought to be for 2 reasons:

- Passing the client in to each `send_x` was showing unnecessary duplication. 
  The [first commit](https://github.com/BlakeWilliams/Elixir-Slack/commit/a5bdd153310f886d36460323ac9dca816dafed55) refactors this parameter into the `slack` map. 
  As I'm not clear on the usecase of changing which client is used per call, I've moved it into an `init` parameter, which makes just as much sense to me given my usecase-unenlightened perspective. This change can be reverted if need be.

- I discovered an odd null-byte padding issue with some message responses.
  The [last commit](https://github.com/BlakeWilliams/Elixir-Slack/commit/2da3367c2013c24c4b3f64bcc15971af9185247e) addresses the issue by stripping these bytes.
  The incoming websocket payload data (the `pong`) in response to `pings` without explicit IDs is padded with 6 extra null bytes for some odd reason. The issue has been mentioned to Slack, and the fix assumes anything before a null byte is the actual intended response.

Should you just want to review the actual implementation, refer to the [middle commit](https://github.com/BlakeWilliams/Elixir-Slack/commit/a438b408444ec84c99adb500850b902768280d08). It's pretty straightforward.