### PR TITLE
Fix a compiler warning in handlers.ex

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -48,7 +48,7 @@ defmodule Slack.Handlers do
     end
   end)
 
-  def handle_slack(%{type: type}, slack) do
+  def handle_slack(%{type: _type}, slack) do
     {:ok, slack}
   end
 end


### PR DESCRIPTION
Easy enough--"type" was unused, and Elixir complained.