### PR TITLE
Add TravisCI for build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: elixir
+elixir:
+  - 1.0.4
+  - 1.0.5
+  - 1.1.0
+env: MIX_ENV=test
+otp_release:
+  - 17.4
+  - 18.0
+after_success:
+  - mix coveralls.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ elixir:
   - 1.1.1
 env: MIX_ENV=test
 otp_release:
-  - 17.4
   - 18.1
 after_success:
   - mix coveralls.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: elixir
 elixir:
-  - 1.0.4
   - 1.0.5
-  - 1.1.0
+  - 1.1.1
 env: MIX_ENV=test
 otp_release:
   - 17.4
-  - 18.0
+  - 18.1
 after_success:
   - mix coveralls.travis

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build
+Status](https://api.travis-ci.org/BlakeWilliams/Elixir-Slack.svg?branch=master)](https://travis-ci.org/BlakeWilliams/Elixir-Slack)
+
 # Elixir-Slack
 
 This is a work in progress Slack [Real Time Messaging API] client for Elixir.


### PR DESCRIPTION
- Add travis CI to run tests against builds.
- Add build status indicator to README.

This resolves issue (https://github.com/BlakeWilliams/Elixir-Slack/issues/21)

Only thing required by repository owner is to.. 
- Goto https://travis-ci.org and sign in with github.
- Visit the page https://travis-ci.org/profile/BlakeWilliams
- Enable Travis CI for the repo `BlakeWilliams/Elixir-Slack`

This is free to use for public repos so there is no cost.  

Please look at https://github.com/afaur/Elixir-Slack for an example of the status indicator working after enabling it on travis-ci.org.  If you look you should see the Build Status as failing since I made some tests fail and pushed the changes into my master branch of my fork of this repo.  

Those tests are not altered in this PR so everything should be passing on merge of these changes.