### PR TITLE
Test travis is working.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ otp_release:
   - 18.1
 after_success:
   - mix coveralls.travis
+


### PR DESCRIPTION
Looks like this repo may not be set up to run on travis as of yet.

Here are the instructions for setting your repo to be monitored.
- Goto https://travis-ci.org and sign in with github.
- Visit the page https://travis-ci.org/profile/BlakeWilliams
- Enable Travis CI for the repo `BlakeWilliams/Elixir-Slack`

If you already completed these tasks let me know..  
I tested this on my fork and everything seems to be working correctly for me.

(The Travis badge at the top of the readme is passing here: https://github.com/afaur/Elixir-Slack)