### PR TITLE
Add handle_info/3

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -47,6 +47,7 @@ defmodule Slack do
   * `handle_connect(slack, state)` - called when connected to Slack.
   * `handle_message(message, slack, state)` - called when a message is received.
   * `handle_close(reason, slack, state)` - called when websocket is closed.
+  * `handle_info(message, slack, state)`
 
   ## Slack argument
 
@@ -105,6 +106,11 @@ defmodule Slack do
         {:ok, state}
       end
 
+      def websocket_info(message, _connection, %{slack: slack, state: state}) do
+        handle_info(message, slack, state)
+        {:ok, %{slack: slack, state: state}}
+      end
+
       def websocket_terminate(reason, _connection, %{slack: slack, state: state}) do
         handle_close(reason, slack, state)
       end
@@ -139,8 +145,9 @@ defmodule Slack do
       def handle_connect(_slack, state), do: {:ok, state}
       def handle_message(_message, _slack, state), do: {:ok, state}
       def handle_close(_reason, _slack, state), do: {:error, state}
+      def handle_info(_message, _slack, state), do: {:ok, state}
 
-      defoverridable [handle_connect: 2, handle_message: 3, handle_close: 3]
+      defoverridable [handle_connect: 2, handle_message: 3, handle_close: 3, handle_info: 3]
     end
   end
 

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -47,7 +47,7 @@ defmodule Slack do
   * `handle_connect(slack, state)` - called when connected to Slack.
   * `handle_message(message, slack, state)` - called when a message is received.
   * `handle_close(reason, slack, state)` - called when websocket is closed.
-  * `handle_info(message, slack, state)`
+  * `handle_info(message, slack, state)` - called when any other message is received in the process mailbox.
 
   ## Slack argument
 


### PR DESCRIPTION
Currently the only defined `websocket_info/3` is [here](https://github.com/BlakeWilliams/Elixir-Slack/blob/master/lib/slack.ex#L104) and so sending any other message to the slack process results in termination of the slack bot since no pattern matches in `websocket_info/3` (which was kind of hard to debug).

This PR adds `handle_info/3` so that all other messages can be handled by the client who does `use Slack`. This is useful for example when passing off a user and message to be posted (that another process generated), like `send(:slack, {user, messge})` (assuming `:slack` is a registered pid that has `use Slack`) and letting the slack process manage all communication to users.