### PR TITLE
Fixes mix release deployment

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Slack.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison, :hackney]]
+    [applications: [:logger, :httpoison, :hackney, :exjsx]]
   end
 
   defp deps do


### PR DESCRIPTION
Without this, the application dies with `undef JSX.decode!`.

The fix is described here: https://hexdocs.pm/exrm/extra-common-issues.html

Quoting the page:

Ensure all dependencies for your application are defined in either the `:applications` or `:included_applications` block of your `mix.exs` file. This is how the build process knows that those dependencies need to be bundled in to the release. **This includes dependencies of your dependencies, if they were not properly configured**. For instance, if you depend on `mongoex`, and `mongoex` depends on `erlang-mongodb`, but `mongoex` doesn’t have `erlang-mongodb` in it’s applications list, your app will fail in it’s release form, because `erlang-mongodb` won’t be loaded.