### PR TITLE
Fix state returned from handle_info

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -107,7 +107,7 @@ defmodule Slack do
       end
 
       def websocket_info(message, _connection, %{slack: slack, state: state}) do
-        handle_info(message, slack, state)
+        {:ok, state} = handle_info(message, slack, state)
         {:ok, %{slack: slack, state: state}}
       end
 


### PR DESCRIPTION
This fixes an issue I was having with implementing `handle_info`.

If I returned new state from my `handle_info` function, the state wasn't being updated. I noticed that in the current implementation of `websocket_info`, there wasn't anything being done with the return value.