### PR TITLE
Ensure members is updated when joining a channel

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -16,6 +16,7 @@ defmodule Slack.Handlers do
     plural_atom = String.to_atom(type <> "s")
 
     def handle_slack(%{type: unquote(type <> "_joined"), channel: channel}, slack) do
+      slack = put_in(slack, [unquote(plural_atom), channel.id, :members], channel.members)
       {:ok, put_in(slack, [unquote(plural_atom), channel.id, :is_member], true)}
     end
     def handle_slack(%{type: unquote(type <> "_left"), channel: channel}, slack) do

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -4,11 +4,12 @@ defmodule Slack.HandlersTest do
 
   test "channel_joined sets is_member to true" do
     {:ok, new_slack} = Handlers.handle_slack(
-      %{type: "channel_joined", channel: %{id: "123"}},
+      %{type: "channel_joined", channel: %{id: "123", members: ["123456", "654321"]}},
       slack
     )
 
     assert new_slack.channels["123"].is_member == true
+    assert new_slack.channels["123"].members == ["123456", "654321"]
   end
 
   test "channel_joined sets is_member to true" do


### PR DESCRIPTION
So it would appear that the members section is blank before joining a channel so if the bot joins the channel after being started it won't have anything in the `members` key. This appears to fix the problem by just making sure the `members` key is replaced with the latest `members` `channel_joined`.