### PR TITLE
Fix the channel_left handler

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -19,7 +19,7 @@ defmodule Slack.Handlers do
       {:ok, put_in(slack, [unquote(plural_atom), channel.id, :is_member], true)}
     end
     def handle_slack(%{type: unquote(type <> "_left"), channel: channel}, slack) do
-      {:ok, put_in(slack, [unquote(plural_atom), channel, :is_member], false)}
+      {:ok, put_in(slack, [unquote(plural_atom), channel.id, :is_member], false)}
     end
     def handle_slack(%{type: unquote(type <> "_rename"), channel: channel}, slack) do
       {:ok, put_in(slack, [unquote(plural_atom), channel.id, :name], channel.name)}

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -11,7 +11,7 @@ defmodule Slack.HandlersTest do
     assert new_slack.channels["123"].is_member == true
   end
 
-  test "channel_joined sets is_member to true" do
+  test "channel_left sets is_member to false" do
     {:ok, new_slack} = Handlers.handle_slack(
       %{type: "channel_left", channel: %{id: "123"}},
       slack


### PR DESCRIPTION
It would appear a simple typo in the test description meant that this
bug was not made apparent. I ran into this while making my other PR
relating to the channel_joined event.