### PR TITLE
Update README.md with handle_connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ callback methods.
 defmodule SlackRtm do
   use Slack
 
-  def init(initial_state, slack) do
+  def handle_connect(slack, state) do
     IO.puts "Connected as #{slack.me.name}"
-    {:ok, initial_state}
+    {:ok, state}
   end
 
   def handle_message(message = %{type: "message"}, slack, state) do


### PR DESCRIPTION
Unless I'm missing something it would appear that `init` is not exposed by the `Slack` module but rather it would appear that `handle_connect` is the correct way to hook into a startup callback.