### PR TITLE
handle channel_join and channel_leave events, update members

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -31,6 +31,12 @@ defmodule Slack.Handlers do
     def handle_slack(%{type: unquote(type <> "_unarchive"), channel: channel}, slack) do
       {:ok, put_in(slack, [unquote(plural_atom), channel, :is_archived], false)}
     end
+    def handle_slack(%{type: "message", subtype: unquote(type <> "_join"), channel: channel, user: user}, slack) do
+      {:ok, put_in(slack, [unquote(plural_atom), channel, :members], [user | slack[unquote(plural_atom)][channel][:members]])}
+    end
+    def handle_slack(%{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user}, slack) do
+      {:ok, put_in(slack, [unquote(plural_atom), channel, :members], slack[unquote(plural_atom)][channel][:members] -- [user])}
+    end
   end)
 
   def handle_slack(%{type: "team_rename", name: name}, slack) do

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -105,6 +105,24 @@ defmodule Slack.HandlersTest do
     assert new_slack.bots["123"].name == "new"
   end
 
+  test "channel_join message should add member" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "message", subtype: "channel_join", user: "U456", channel: "123"},
+      slack
+    )
+
+    assert (new_slack.channels["123"].members |> Enum.sort) == ["U123", "U456"]
+  end
+
+  test "channel_leave message should remove member" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "message", subtype: "channel_leave", user: "U123", channel: "123"},
+      slack
+    )
+
+    assert new_slack.channels["123"].members == []
+  end
+
   defp slack do
     %{
       channels: %{
@@ -112,7 +130,8 @@ defmodule Slack.HandlersTest do
           id: 123,
           name: "foo",
           is_member: nil,
-          is_archived: nil
+          is_archived: nil,
+          members: ["U123"]
         }
       },
       team: %{


### PR DESCRIPTION
In the current implementation our local `slack` cache is out of date if other people leave or join a channel we are in. According to the slack documentation for [channel_join](https://api.slack.com/events/message/channel_join) and [channel_leave](https://api.slack.com/events/message/channel_leave) we will get a message with these subtypes whenever somebody else joins or leaves a channel that we're in. It would seem then that we should add/remove those members from the slack cache under those circumstances.

Let me know if you think this doesn't make sense or could be simplified. Thanks for the speedy merges on our other PRs.