### PR TITLE
Update slack state before forwarding messages

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -122,8 +122,8 @@ defmodule Slack do
       def websocket_handle({:text, message}, _con, %{slack: slack, state: state}) do
         message = prepare_message message
         if Map.has_key?(message, :type) do
-          {:ok, state} = handle_message(message, slack, state)
           {:ok, slack} = handle_slack(message, slack)
+          {:ok, state} = handle_message(message, slack, state)
         end
 
         {:ok, %{slack: slack, state: state}}


### PR DESCRIPTION
I'm not 100% sure this is the desired behavior for all use cases but for us at least this is what we want. The main reason this is necessary is that when we receive `:channel_joined` events we are joining a channel for the first time which means we don't have the `members`. If we don't call `handle_slack` first then the `members` key is empty and our `channel_joined` handler doesn't have access to that vital piece of information.