### PR TITLE
Handle group interactions

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -20,11 +20,6 @@ defmodule Slack.Handlers do
   end
 
   def handle_slack(%{type: "group_joined", channel: channel}, slack) do
-    # Sent when a user joins / is invited to a group. The bot is a
-    # member of the group by definition, and it will actually be
-    # listed in the members list
-    #
-    # Slack doesn't have a group_created event!
     {:ok, put_in(slack, [:groups, channel.id], channel)}
   end
 
@@ -33,12 +28,6 @@ defmodule Slack.Handlers do
   end
 
   def handle_slack(%{type: "message", subtype: "group_join", channel: channel, user: user}, slack) do
-    # When the bot joins a group, it gets both a group_joined event
-    # _and_ a group_join message. It also gets a group_join message
-    # when other users join the group. As a result, we need to make
-    # sure the members are unique and not duplicated)
-
-    # Note: here, channel is just the ID
     {:ok, update_in(slack, [:groups, channel, :members], &(Enum.uniq([user | &1])))}
   end
 
@@ -47,8 +36,6 @@ defmodule Slack.Handlers do
   end
 
   def handle_slack(%{type: "group_left", channel: channel}, slack) do
-    # When the user leaves the group, they're out for good; no use in
-    # continuing to track ittt
     {:ok, update_in(slack, [:groups], &(Map.delete(&1, channel)))}
   end
 

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -125,9 +125,10 @@ defmodule Slack.HandlersTest do
 
   test "group_joined event should add group" do
     {:ok, new_slack} = Handlers.handle_slack(
-      %{type: "group_joined", channel:
-        %{id: "G123", members: ["U123", "U456"]}},
-      slack)
+      %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
+      slack
+    )
+
     assert new_slack.groups["G123"]
     assert new_slack.groups["G123"].members == ["U123", "U456"]
   end
@@ -135,20 +136,27 @@ defmodule Slack.HandlersTest do
   test "group_join message should add user to member list" do
     {:ok, new_slack} = Handlers.handle_slack(
       %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
-      slack)
+      slack
+    )
+
     assert Enum.member?(new_slack.groups["G000"][:members], "U000")
   end
 
   test "group_leave message should remove user from member list" do
     {:ok, new_slack} = Handlers.handle_slack(
       %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
-      slack)
+      slack
+    )
+
     refute Enum.member?(new_slack.groups["G000"].members, "U111")
   end
 
   test "group_left message should remove group altogether" do
     {:ok, new_slack} = Handlers.handle_slack(
-      %{type: "group_left", channel: "G000"}, slack)
+      %{type: "group_left", channel: "G000"},
+      slack
+    )
+
     refute new_slack.groups["G000"]
   end
 
@@ -172,7 +180,10 @@ defmodule Slack.HandlersTest do
         }
       },
       groups: %{
-        "G000" => %{name: "secret-group", members: ["U111", "U222"]}
+        "G000" => %{
+          name: "secret-group",
+          members: ["U111", "U222"]
+        }
       },
       bots: %{
         "123": %{

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -123,6 +123,35 @@ defmodule Slack.HandlersTest do
     assert new_slack.channels["123"].members == []
   end
 
+  test "group_joined event should add group" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "group_joined", channel:
+        %{id: "G123", members: ["U123", "U456"]}},
+      slack)
+    assert new_slack.groups["G123"]
+    assert new_slack.groups["G123"].members == ["U123", "U456"]
+  end
+
+  test "group_join message should add user to member list" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
+      slack)
+    assert Enum.member?(new_slack.groups["G000"][:members], "U000")
+  end
+
+  test "group_leave message should remove user from member list" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
+      slack)
+    refute Enum.member?(new_slack.groups["G000"].members, "U111")
+  end
+
+  test "group_left message should remove group altogether" do
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "group_left", channel: "G000"}, slack)
+    refute new_slack.groups["G000"]
+  end
+
   defp slack do
     %{
       channels: %{
@@ -141,6 +170,9 @@ defmodule Slack.HandlersTest do
         "123": %{
           name: "Bar"
         }
+      },
+      groups: %{
+        "G000" => %{name: "secret-group", members: ["U111", "U222"]}
       },
       bots: %{
         "123": %{


### PR DESCRIPTION
Previously, interacting with private groups would fail; Slack does not
have a `group_created` event to parallel its `channel_created` event,
and so the code would crash trying to update data nested under `nil`
whenever a `group_joined` event came in.

To address this, the previously common implementation for channel and
group event handling was split to the extent necessary for dealing with
group interactions. When receiving a `group_joined` event, we simply add
the group map to the `slack` object. There is no reason to keep track of
an `is_member` key, since the user must be a member of the group by
definition.

Users joining and leaving a group is also handled. It turns out that
both a `group_joined` event as well as a `group_join` message are
received, so we ensure that the list of members is maintained
effectively as a set to prevent duplicates.

Finally, when a `group_left` event is received, we simply remove all
record of the group from the `slack` object, since the user is no longer
a member.

Tests included.