### PR TITLE
Fix channel_left handler

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -31,8 +31,8 @@ defmodule Slack.Handlers do
     {:ok, update_in(slack, [:groups, channel, :members], &(Enum.uniq([user | &1])))}
   end
 
-  def handle_slack(%{type: "channel_left", channel: channel}, slack) do
-    {:ok, put_in(slack, [:channels, channel.id, :is_member], false)}
+  def handle_slack(%{type: "channel_left", channel: channel_id}, slack) do
+    {:ok, put_in(slack, [:channels, channel_id, :is_member], false)}
   end
 
   def handle_slack(%{type: "group_left", channel: channel}, slack) do

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -14,7 +14,7 @@ defmodule Slack.HandlersTest do
 
   test "channel_left sets is_member to false" do
     {:ok, new_slack} = Handlers.handle_slack(
-      %{type: "channel_left", channel: %{id: "123"}},
+      %{type: "channel_left", channel: "123"},
       slack
     )
 


### PR DESCRIPTION
It would appear from the
[docs](https://api.slack.com/events/channel_left) and local testing that
slack is only giving the id of the channel for channel_left events.
Funnily enough I just submitted PR #40 that changed this the other way
around before, but it is for some reason broken. That might have been an
oversight from before.