### PR TITLE
Fix an unused variable warning

### DIFF
--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -12,7 +12,7 @@ defmodule Slack.Handlers do
     {:ok, put_in(slack, [:channels, channel.id], channel)}
   end
 
-  def handle_slack(%{type: "channel_joined", channel: channel}=x, slack) do
+  def handle_slack(%{type: "channel_joined", channel: channel}, slack) do
     slack = slack
     |> put_in([:channels, channel.id, :members], channel.members)
     |> put_in([:channels, channel.id, :is_member], true)


### PR DESCRIPTION
Fix this warning

```
==> slack
Compiled lib/slack/rtm.ex
Compiled lib/slack.ex
lib/slack/handlers.ex:15: warning: variable x is unused
Compiled lib/slack/handlers.ex
Generated slack app
```