### PR TITLE
Add send_attachments function

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -171,6 +171,28 @@ defmodule Slack do
   end
 
   @doc """
+  Sends `text` and `attachments` to `channel` for the given `slack` connection.
+  The `attachments` should be a list of maps, see the [Slack attachment docs] for
+  information on how to structure attachments.
+
+  [Slack attachment docs]: https://api.slack.com/docs/attachments
+  """
+  def send_attachments(text, attachments, channel, slack) when is_list(attachments) do
+    message = %{
+      type: "message",
+      text: text,
+      attachments: attachments,
+      channel: channel
+    }
+
+    message |> JSX.encode! |> send_raw(slack)
+  end
+
+  def send_attachments(text, attachment, channel, slack) do
+    send_attachments(text, [attachment], channel, slack)
+  end
+
+  @doc """
   Notifies Slack that the current user is typing in `channel`.
   """
   def indicate_typing(channel, slack) do

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -29,6 +29,15 @@ defmodule SlackTest do
     assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
   end
 
+  test "send_attachments sends message + attachments formatted to client" do
+    attachment = %{
+      title: "Attachment",
+      color: "#fff",
+    }
+    result = Slack.send_attachments("hello", [attachment], "channel", %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"attachments":[{"color":"#fff","title":"Attachment"}],"channel":"channel","text":"hello","type":"message"}/, nil}
+  end
+
   test "indicate_typing sends typing notification to client" do
     result = Slack.indicate_typing("channel", %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"channel":"channel","type":"typing"}/, nil}


### PR DESCRIPTION
Messages can have [attachments](https://api.slack.com/docs/attachments) on them, this adds the `send_attachments`
function to expose this feature. Previously, this feature could only be
utilized by using `send_raw`.

Wasn't sure if there should be two versions of this function, one accepting a single attachment and another accepting a list. I thought I would put this out there to see if there was any interest before adding too much.