### PR TITLE
Support Sending Messages to Channels and Users by Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ as the third.
 
 The passed in `slack` state holds the current user properties as `me`, team
 properties as `team`, the current websocket connection as `socket`, and a list
-of  `bots`, `channels`, `groups`, and `users`.
+of  `bots`, `channels`, `groups`, `users`, and `ims` (direct message channels).
 
 [rtm.start]: https://api.slack.com/methods/rtm.start
 

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -63,6 +63,7 @@ defmodule Slack do
   * channels - Stored as a map with id's as keys.
   * groups - Stored as a map with id's as keys.
   * users - Stored as a map with id's as keys.
+  * ims (direct message channels) - Stored as a map with id's as keys.
   * socket - The connection to Slack.
   * client - The client that makes calls to Slack.
 

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -77,6 +77,8 @@ defmodule Slack do
       @behaviour :websocket_client_handler
       import Slack
       import Slack.Handlers
+      import Slack.Lookups
+      import Slack.Sends
 
       def start_link(token, initial_state, client \\ :websocket_client) do
         case Slack.Rtm.start(token) do
@@ -163,134 +165,5 @@ defmodule Slack do
 
       defoverridable [handle_connect: 2, handle_message: 3, handle_close: 3, handle_info: 3]
     end
-  end
-
-  @doc ~S"""
-  Turns a string like `"@USER_NAME"` into the ID that Slack understands (`"U…"`).
-  """
-  def lookup_user_id("@" <> user_name, slack) do
-    slack.users
-    |> Map.values
-    |> Enum.find(%{ }, fn user -> user.name == user_name end)
-    |> Map.get(:id)
-  end
-
-  @doc ~S"""
-  Turns a string like `"@USER_NAME"` or a user ID (`"U…"`) into the ID for the
-  direct message channel of that user (`"D…"`).  `nil` is returned if a direct
-  message channel has not yet been opened.
-  """
-  def lookup_direct_message_id(user = "@" <> _user_name, slack) do
-    user
-    |> lookup_user_id(slack)
-    |> lookup_direct_message_id(slack)
-  end
-  def lookup_direct_message_id(user_id, slack) do
-    slack.ims
-    |> Map.values
-    |> Enum.find(%{ }, fn direct_message -> direct_message.user == user_id end)
-    |> Map.get(:id)
-  end
-
-  @doc ~S"""
-  Turns a string like `"@CHANNEL_NAME"` into the ID that Slack understands
-  (`"C…"`).
-  """
-  def lookup_channel_id("#" <> channel_name, slack) do
-    slack.channels
-    |> Map.values
-    |> Enum.find(fn channel -> channel.name == channel_name end)
-    |> Map.get(:id)
-  end
-
-  @doc ~S"""
-  Turns a Slack user ID (`"U…"`) or direct message ID (`"D…"`) into a string in
-  the format "@USER_NAME".
-  """
-  def lookup_user_name(direct_message_id = "D" <> _id, slack) do
-    lookup_user_name(slack.ims[direct_message_id].user, slack)
-  end
-  def lookup_user_name(user_id = "U" <> _id, slack) do
-    "@" <> slack.users[user_id].name
-  end
-
-  @doc ~S"""
-  Turns a Slack channel ID (`"C…"`) into a string in the format "#CHANNEL_NAME".
-  """
-  def lookup_channel_name(channel_id = "C" <> _id, slack) do
-    "#" <> slack.channels[channel_id].name
-  end
-
-  @doc """
-  Sends `text` to `channel` for the given `slack` connection.  `channel` can be
-  a string in the format of `"#CHANNEL_NAME"`, `"@USER_NAME"`, or any ID that
-  Slack understands.
-  """
-  def send_message(text, channel = "#" <> channel_name, slack) do
-    channel_id = lookup_channel_id(channel, slack)
-    if channel_id do
-      send_message(text, channel_id, slack)
-    else
-      raise ArgumentError, "channel ##{channel_name} not found"
-    end
-  end
-  def send_message(text, user = "@" <> user_name, slack) do
-    direct_message_id = lookup_direct_message_id(user, slack)
-    if direct_message_id do
-      send_message(text, direct_message_id, slack)
-    else
-      im_open = HTTPoison.post(
-        "https://slack.com/api/im.open",
-        {:form, [token: slack.token, user: lookup_user_id(user, slack)]}
-      )
-      case im_open do
-        {:ok, response} ->
-          case JSX.decode!(response.body, [{:labels, :atom}]) do
-            %{ok: true, channel: %{id: id}} -> send_message(text, id, slack)
-            _ -> :delivery_failed
-          end
-        {:error, reason} -> :delivery_failed
-      end
-    end
-  end
-  def send_message(text, channel, slack) do
-    %{
-      type: "message",
-      text: text,
-      channel: channel
-    }
-      |> JSX.encode!
-      |> send_raw(slack)
-  end
-
-  @doc """
-  Notifies Slack that the current user is typing in `channel`.
-  """
-  def indicate_typing(channel, slack) do
-    %{
-      type: "typing",
-      channel: channel
-    }
-      |> JSX.encode!
-      |> send_raw(slack)
-  end
-
-  @doc """
-  Notifies slack that the current `slack` user is typing in `channel`.
-  """
-  def send_ping(data \\ [], slack) do
-    %{
-      type: "ping"
-    }
-      |> Dict.merge(data)
-      |> JSX.encode!
-      |> send_raw(slack)
-  end
-
-  @doc """
-  Sends raw JSON to a given socket.
-  """
-  def send_raw(json, %{socket: socket, client: client}) do
-    client.send({:text, json}, socket)
   end
 end

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -102,6 +102,7 @@ defmodule Slack do
           channels: rtm_list_to_map(rtm.channels),
           groups: rtm_list_to_map(rtm.groups),
           users: rtm_list_to_map(rtm.users),
+          ims: rtm_list_to_map(rtm.ims)
         }
 
         {:ok, state} = handle_connect(slack, state)
@@ -157,19 +158,81 @@ defmodule Slack do
     end
   end
 
-  @doc """
-  Sends `text` to `channel` for the given `slack` connection.
+  @doc ~S"""
+  Turns a string like `"@USER_NAME"` into the ID that Slack understands (`"U…"`).
   """
-  def send_message(text, "#" <> channel_name, slack) do
-    channel_id =
-      slack.channels
-      |> Map.values
-      |> Enum.find(fn channel -> channel.name == channel_name end)
-      |> Map.get(:id)
+  def lookup_user_id("@" <> user_name, slack) do
+    slack.users
+    |> Map.values
+    |> Enum.find(fn user -> user.name == user_name end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a string like `"@USER_NAME"` or a user ID (`"U…"`) into the ID for the
+  direct message channel of that user (`"D…"`).  `nil` is returned if a direct
+  message channel has not yet been opened.
+  """
+  def lookup_direct_message_id(user = "@" <> _user_name, slack) do
+    user
+    |> lookup_user_id(slack)
+    |> lookup_direct_message_id(slack)
+  end
+  def lookup_direct_message_id(user_id, slack) do
+    slack.ims
+    |> Map.values
+    |> Enum.find(fn direct_message -> direct_message.user == user_id end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a string like `"@CHANNEL_NAME"` into the ID that Slack understands
+  (`"C…"`).
+  """
+  def lookup_channel_id("#" <> channel_name, slack) do
+    slack.channels
+    |> Map.values
+    |> Enum.find(fn channel -> channel.name == channel_name end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a Slack user ID (`"U…"`) or direct message ID (`"D…"`) into a string in
+  the format "@USER_NAME".
+  """
+  def lookup_user_name(direct_message_id = "D" <> _id, slack) do
+    lookup_user_name(slack.ims[direct_message_id].user, slack)
+  end
+  def lookup_user_name(user_id = "U" <> _id, slack) do
+    "@" <> slack.users[user_id].name
+  end
+
+  @doc ~S"""
+  Turns a Slack channel ID (`"C…"`) into a string in the format "#CHANNEL_NAME".
+  """
+  def lookup_channel_name(channel_id = "C" <> _id, slack) do
+    "#" <> slack.channels[channel_id].name
+  end
+
+  @doc """
+  Sends `text` to `channel` for the given `slack` connection.  `channel` can be
+  a string in the format of `"#CHANNEL_NAME"`, `"@USER_NAME"`, or any ID that
+  Slack understands.
+  """
+  def send_message(text, channel = "#" <> channel_name, slack) do
+    channel_id = lookup_channel_id(channel, slack)
     if channel_id do
       send_message(text, channel_id, slack)
     else
       raise ArgumentError, "channel ##{channel_name} not found"
+    end
+  end
+  def send_message(text, user = "@" <> user_name, slack) do
+    direct_message_id = lookup_direct_message_id(user, slack)
+    if direct_message_id do
+      send_message(text, direct_message_id, slack)
+    else
+      raise ArgumentError, "direct message channel for ##{user_name} not found"
     end
   end
   def send_message(text, channel, slack) do

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -160,6 +160,18 @@ defmodule Slack do
   @doc """
   Sends `text` to `channel` for the given `slack` connection.
   """
+  def send_message(text, "#" <> channel_name, slack) do
+    channel_id =
+      slack.channels
+      |> Map.values
+      |> Enum.find(fn channel -> channel.name == channel_name end)
+      |> Map.get(:id)
+    if channel_id do
+      send_message(text, channel_id, slack)
+    else
+      raise ArgumentError, "channel ##{channel_name} not found"
+    end
+  end
   def send_message(text, channel, slack) do
     %{
       type: "message",

--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -72,6 +72,10 @@ defmodule Slack.Handlers do
     end
   end)
 
+  def handle_slack(%{type: "im_created", channel: channel}, slack) do
+    {:ok, put_in(slack, [:ims, channel.id], channel)}
+  end
+
   def handle_slack(%{type: _type}, slack) do
     {:ok, slack}
   end

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -1,0 +1,57 @@
+defmodule Slack.Lookups do
+  @doc ~S"""
+  Turns a string like `"@USER_NAME"` into the ID that Slack understands (`"U…"`).
+  """
+  def lookup_user_id("@" <> user_name, slack) do
+    slack.users
+    |> Map.values
+    |> Enum.find(%{ }, fn user -> user.name == user_name end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a string like `"@USER_NAME"` or a user ID (`"U…"`) into the ID for the
+  direct message channel of that user (`"D…"`).  `nil` is returned if a direct
+  message channel has not yet been opened.
+  """
+  def lookup_direct_message_id(user = "@" <> _user_name, slack) do
+    user
+    |> lookup_user_id(slack)
+    |> lookup_direct_message_id(slack)
+  end
+  def lookup_direct_message_id(user_id, slack) do
+    slack.ims
+    |> Map.values
+    |> Enum.find(%{ }, fn direct_message -> direct_message.user == user_id end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a string like `"@CHANNEL_NAME"` into the ID that Slack understands
+  (`"C…"`).
+  """
+  def lookup_channel_id("#" <> channel_name, slack) do
+    slack.channels
+    |> Map.values
+    |> Enum.find(fn channel -> channel.name == channel_name end)
+    |> Map.get(:id)
+  end
+
+  @doc ~S"""
+  Turns a Slack user ID (`"U…"`) or direct message ID (`"D…"`) into a string in
+  the format "@USER_NAME".
+  """
+  def lookup_user_name(direct_message_id = "D" <> _id, slack) do
+    lookup_user_name(slack.ims[direct_message_id].user, slack)
+  end
+  def lookup_user_name(user_id = "U" <> _id, slack) do
+    "@" <> slack.users[user_id].name
+  end
+
+  @doc ~S"""
+  Turns a Slack channel ID (`"C…"`) into a string in the format "#CHANNEL_NAME".
+  """
+  def lookup_channel_name(channel_id = "C" <> _id, slack) do
+    "#" <> slack.channels[channel_id].name
+  end
+end

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -1,0 +1,87 @@
+defmodule Slack.Sends do
+  alias Slack.Lookups
+
+  @doc """
+  Sends `text` to `channel` for the given `slack` connection.  `channel` can be
+  a string in the format of `"#CHANNEL_NAME"`, `"@USER_NAME"`, or any ID that
+  Slack understands.
+  """
+  def send_message(text, channel = "#" <> channel_name, slack) do
+    channel_id = Lookups.lookup_channel_id(channel, slack)
+
+    if channel_id do
+      send_message(text, channel_id, slack)
+    else
+      raise ArgumentError, "channel ##{channel_name} not found"
+    end
+  end
+  def send_message(text, user = "@" <> _user_name, slack) do
+    direct_message_id = Lookups.lookup_direct_message_id(user, slack)
+
+    if direct_message_id do
+      send_message(text, direct_message_id, slack)
+    else
+      open_im_channel(
+        slack.token,
+        Lookups.lookup_user_id(user, slack),
+        fn id -> send_message(text, id, slack) end,
+        fn _reason -> :delivery_failed end
+      )
+    end
+  end
+  def send_message(text, channel, slack) do
+    %{
+      type: "message",
+      text: text,
+      channel: channel
+    }
+      |> JSX.encode!
+      |> send_raw(slack)
+  end
+
+  @doc """
+  Notifies Slack that the current user is typing in `channel`.
+  """
+  def indicate_typing(channel, slack) do
+    %{
+      type: "typing",
+      channel: channel
+    }
+      |> JSX.encode!
+      |> send_raw(slack)
+  end
+
+  @doc """
+  Notifies slack that the current `slack` user is typing in `channel`.
+  """
+  def send_ping(data \\ [], slack) do
+    %{
+      type: "ping"
+    }
+      |> Dict.merge(data)
+      |> JSX.encode!
+      |> send_raw(slack)
+  end
+
+  @doc """
+  Sends raw JSON to a given socket.
+  """
+  def send_raw(json, %{socket: socket, client: client}) do
+    client.send({:text, json}, socket)
+  end
+
+  defp open_im_channel(token, user_id, on_success, on_error) do
+    im_open = HTTPoison.post(
+      "https://slack.com/api/im.open",
+      {:form, [token: token, user: user_id]}
+    )
+    case im_open do
+      {:ok, response} ->
+        case JSX.decode!(response.body, [{:labels, :atom}]) do
+          %{ok: true, channel: %{id: id}} -> on_success.(id)
+          _ -> on_error.()
+        end
+      {:error, reason} -> on_error.(reason)
+    end
+  end
+end

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -160,6 +160,16 @@ defmodule Slack.HandlersTest do
     refute new_slack.groups["G000"]
   end
 
+  test "im_created message should add direct message channel to list" do
+    channel = %{name: "channel", id: "C456"}
+    {:ok, new_slack} = Handlers.handle_slack(
+      %{type: "im_created", channel: channel},
+      slack
+    )
+
+    assert new_slack.ims == %{"C456" => channel}
+  end
+
   defp slack do
     %{
       channels: %{
@@ -189,7 +199,8 @@ defmodule Slack.HandlersTest do
         "123": %{
           name: "Bot"
         }
-      }
+      },
+      ims: %{ }
     }
   end
 end

--- a/test/slack/lookups_test.exs
+++ b/test/slack/lookups_test.exs
@@ -1,0 +1,47 @@
+defmodule Slack.LookupsTest do
+  use ExUnit.Case
+  alias Slack.Lookups
+
+  test "turns @user into a user identifier" do
+    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    assert Lookups.lookup_user_id("@user", slack) == "U123"
+  end
+
+  test "turns @user into direct message identifier, if the channel exists" do
+    slack = %{
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    assert Lookups.lookup_direct_message_id("@user", slack) == "D789"
+    assert Lookups.lookup_direct_message_id("@missing", slack) == nil
+  end
+
+  test "turns a user identifier into direct message identifier, if the channel exists" do
+    slack = %{ims: %{"D789" => %{user: "U123", id: "D789"}}}
+    assert Lookups.lookup_direct_message_id("U123", slack) == "D789"
+    assert Lookups.lookup_direct_message_id("U000", slack) == nil
+  end
+
+  test "turns #channel into a channel identifier" do
+    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
+    assert Lookups.lookup_channel_id("#channel", slack) == "C456"
+  end
+
+  test "turns a user identifier into @user" do
+    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    assert Lookups.lookup_user_name("U123", slack) == "@user"
+  end
+
+  test "turns a direct message identifier into @user" do
+    slack = %{
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    assert Lookups.lookup_user_name("D789", slack) == "@user"
+  end
+
+  test "turns a channel identifier into #channel" do
+    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
+    assert Lookups.lookup_channel_name("C456", slack) == "#channel"
+  end
+end

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -1,0 +1,56 @@
+defmodule Slack.SendsTest do
+  use ExUnit.Case
+  alias Slack.Sends
+
+  defmodule FakeWebsocketClient do
+    def send({:text, json}, socket) do
+      {json, socket}
+    end
+  end
+
+  test "send_raw sends slack formatted to client" do
+    result = Sends.send_raw(~s/{"text": "foo"}/, %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"text": "foo"}/, nil}
+  end
+
+  test "send_message sends message formatted to client" do
+    result = Sends.send_message("hello", "channel", %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
+  end
+
+  test "send_message understands #channel names" do
+    slack = %{
+      socket: nil,
+      client: FakeWebsocketClient,
+      channels: %{"C456" => %{name: "channel", id: "C456"}}
+    }
+    result = Sends.send_message("hello", "#channel", slack)
+    assert result == {~s/{"channel":"C456","text":"hello","type":"message"}/, nil}
+  end
+
+  test "send_message understands @user names" do
+    slack = %{
+      socket: nil,
+      client: FakeWebsocketClient,
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    result = Sends.send_message("hello", "@user", slack)
+    assert result == {~s/{"channel":"D789","text":"hello","type":"message"}/, nil}
+  end
+
+  test "indicate_typing sends typing notification to client" do
+    result = Sends.indicate_typing("channel", %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"channel":"channel","type":"typing"}/, nil}
+  end
+
+  test "send_ping sends ping to client" do
+    result = Sends.send_ping(%{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"type":"ping"}/, nil}
+  end
+
+  test "send_ping with data sends ping + data to client" do
+    result = Sends.send_ping([foo: :bar], %{socket: nil, client: FakeWebsocketClient})
+    assert result == {~s/{"foo":"bar","type":"ping"}/, nil}
+  end
+end

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -5,107 +5,12 @@ defmodule SlackTest do
     use Slack
   end
 
-  defmodule FakeWebsocketClient do
-    def send({:text, json}, socket) do
-      {json, socket}
-    end
-  end
-
   test "on_connect returns state by default" do
     assert Bot.handle_connect(nil, 1) == {:ok, 1}
   end
 
   test "handle_message returns state by default" do
     assert Bot.handle_message(nil, nil, 1) == {:ok, 1}
-  end
-
-  test "turns @user into a user identifier" do
-    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
-    assert Slack.lookup_user_id("@user", slack) == "U123"
-  end
-
-  test "turns @user into direct message identifier, if the channel exists" do
-    slack = %{
-      users: %{"U123" => %{name: "user", id: "U123"}},
-      ims: %{"D789" => %{user: "U123", id: "D789"}}
-    }
-    assert Slack.lookup_direct_message_id("@user", slack) == "D789"
-    assert Slack.lookup_direct_message_id("@missing", slack) == nil
-  end
-
-  test "turns a user identifier into direct message identifier, if the channel exists" do
-    slack = %{ims: %{"D789" => %{user: "U123", id: "D789"}}}
-    assert Slack.lookup_direct_message_id("U123", slack) == "D789"
-    assert Slack.lookup_direct_message_id("U000", slack) == nil
-  end
-
-  test "turns #channel into a channel identifier" do
-    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
-    assert Slack.lookup_channel_id("#channel", slack) == "C456"
-  end
-
-  test "turns a user identifier into @user" do
-    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
-    assert Slack.lookup_user_name("U123", slack) == "@user"
-  end
-
-  test "turns a direct message identifier into @user" do
-    slack = %{
-      users: %{"U123" => %{name: "user", id: "U123"}},
-      ims: %{"D789" => %{user: "U123", id: "D789"}}
-    }
-    assert Slack.lookup_user_name("D789", slack) == "@user"
-  end
-
-  test "turns a channel identifier into #channel" do
-    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
-    assert Slack.lookup_channel_name("C456", slack) == "#channel"
-  end
-
-  test "send_raw sends slack formatted to client" do
-    result = Slack.send_raw(~s/{"text": "foo"}/, %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"text": "foo"}/, nil}
-  end
-
-  test "send_message sends message formatted to client" do
-    result = Slack.send_message("hello", "channel", %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
-  end
-
-  test "send_message understands #channel names" do
-    slack = %{
-      socket: nil,
-      client: FakeWebsocketClient,
-      channels: %{"C456" => %{name: "channel", id: "C456"}}
-    }
-    result = Slack.send_message("hello", "#channel", slack)
-    assert result == {~s/{"channel":"C456","text":"hello","type":"message"}/, nil}
-  end
-
-  test "send_message understands @user names" do
-    slack = %{
-      socket: nil,
-      client: FakeWebsocketClient,
-      users: %{"U123" => %{name: "user", id: "U123"}},
-      ims: %{"D789" => %{user: "U123", id: "D789"}}
-    }
-    result = Slack.send_message("hello", "@user", slack)
-    assert result == {~s/{"channel":"D789","text":"hello","type":"message"}/, nil}
-  end
-
-  test "indicate_typing sends typing notification to client" do
-    result = Slack.indicate_typing("channel", %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"channel":"channel","type":"typing"}/, nil}
-  end
-
-  test "send_ping sends ping to client" do
-    result = Slack.send_ping(%{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"type":"ping"}/, nil}
-  end
-
-  test "send_ping with data sends ping + data to client" do
-    result = Slack.send_ping([foo: :bar], %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"foo":"bar","type":"ping"}/, nil}
   end
 
   test "init formats rtm results properly" do

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -19,6 +19,49 @@ defmodule SlackTest do
     assert Bot.handle_message(nil, nil, 1) == {:ok, 1}
   end
 
+  test "turns @user into a user identifier" do
+    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    assert Slack.lookup_user_id("@user", slack) == "U123"
+  end
+
+  test "turns @user into direct message identifier, if the channel exists" do
+    slack = %{
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    assert Slack.lookup_direct_message_id("@user", slack) == "D789"
+    assert Slack.lookup_direct_message_id("@missing", slack) == nil
+  end
+
+  test "turns a user identifier into direct message identifier, if the channel exists" do
+    slack = %{ims: %{"D789" => %{user: "U123", id: "D789"}}}
+    assert Slack.lookup_direct_message_id("U123", slack) == "D789"
+    assert Slack.lookup_direct_message_id("U000", slack) == nil
+  end
+
+  test "turns #channel into a channel identifier" do
+    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
+    assert Slack.lookup_channel_id("#channel", slack) == "C456"
+  end
+
+  test "turns a user identifier into @user" do
+    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    assert Slack.lookup_user_name("U123", slack) == "@user"
+  end
+
+  test "turns a direct message identifier into @user" do
+    slack = %{
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    assert Slack.lookup_user_name("D789", slack) == "@user"
+  end
+
+  test "turns a channel identifier into #channel" do
+    slack = %{channels: %{"C456" => %{name: "channel", id: "C456"}}}
+    assert Slack.lookup_channel_name("C456", slack) == "#channel"
+  end
+
   test "send_raw sends slack formatted to client" do
     result = Slack.send_raw(~s/{"text": "foo"}/, %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"text": "foo"}/, nil}
@@ -27,6 +70,27 @@ defmodule SlackTest do
   test "send_message sends message formatted to client" do
     result = Slack.send_message("hello", "channel", %{socket: nil, client: FakeWebsocketClient})
     assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
+  end
+
+  test "send_message understands #channel names" do
+    slack = %{
+      socket: nil,
+      client: FakeWebsocketClient,
+      channels: %{"C456" => %{name: "channel", id: "C456"}}
+    }
+    result = Slack.send_message("hello", "#channel", slack)
+    assert result == {~s/{"channel":"C456","text":"hello","type":"message"}/, nil}
+  end
+
+  test "send_message understands @user names" do
+    slack = %{
+      socket: nil,
+      client: FakeWebsocketClient,
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    result = Slack.send_message("hello", "@user", slack)
+    assert result == {~s/{"channel":"D789","text":"hello","type":"message"}/, nil}
   end
 
   test "indicate_typing sends typing notification to client" do
@@ -52,9 +116,10 @@ defmodule SlackTest do
       channels: [%{id: "123"}],
       groups: [%{id: "123"}],
       users: [%{id: "123"}],
+      ims: [%{id: "123"}]
     }
 
-    {:ok, %{slack: slack, state: state}} = Bot.init(%{rtm: rtm, state: 1, client: FakeWebsocketClient}, nil)
+    {:ok, %{slack: slack, state: state}} = Bot.init(%{rtm: rtm, state: 1, client: FakeWebsocketClient, token: "ABC"}, nil)
 
     assert slack.me.name == "fake"
     assert slack.team.name == "Foo"
@@ -62,6 +127,7 @@ defmodule SlackTest do
     assert slack.channels == %{"123" => %{id: "123"}}
     assert slack.groups   == %{"123" => %{id: "123"}}
     assert slack.users    == %{"123" => %{id: "123"}}
+    assert slack.ims      == %{"123" => %{id: "123"}}
 
     assert state == 1
   end


### PR DESCRIPTION
The main change here is that `Slack.send_message/2` is enhanced to understand calls in these formats:

* `Slack.send_message("whatever", "#some_channel")`
* `Slack.send_message("whatever", "@some_user")`

The latter sends a direct message to a user.  If you have never communicated with them privately before, a separate call is made to the Slack Web API to open a channel and then the message is sent.  Bots now track these direct message channels as part of their state.

Convenience functions were also added to lookup names and identifiers.

**Potential problems with my changes**:

My new code should not effect existing code.  You have to use these new features to be affected by the changes.

My name lookup strategy isn't ideal since it scans through `Map` values.  This probably isn't slow enough to worry about under normal circumstances and it required the smallest amount of changes.  It can be optimized if needed be adding and maintaining an internal mapping of names to Slack identifiers.

I didn't fully test everything since a call to an external API is involved and it didn't look like the test suite had been dealing with those.