### PR TITLE
Handles general json parse errors and special throttled case.

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -95,6 +95,8 @@ defmodule Slack do
             {:error, "Timed out while connecting to the Slack RTM API"}
           {:error, %HTTPoison.Error{reason: :nxdomain}} ->
             {:error, "Could not connect to the Slack RTM API"}
+          {:error, %JSX.DecodeError{string: "You are sending too many requests. Please relax."}} ->
+            {:error, "Sent too many connection requests at once to the Slack RTM API."}
           {:error, error} ->
             {:error, error}
         end

--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -1,12 +1,22 @@
+defmodule JSX.DecodeError do
+  defexception [:reason, :string]
+  
+  def message(%JSX.DecodeError{reason: reason, string: string}) do
+    "JSX could not decode string for reason: `:#{reason}`, string given:\n#{string}"
+  end
+end
+
 defmodule Slack.Rtm do
   @moduledoc false
   @url "https://slack.com/api/rtm.start?token="
 
   def start(token) do
     case HTTPoison.get(@url <> token) do
-      {:ok, response} ->
-        json = JSX.decode!(response.body, [{:labels, :atom}])
-        {:ok, json}
+      {:ok, %HTTPoison.Response{body: body} } ->
+        case JSX.decode(body, [{:labels, :atom}]) do
+          {:ok, json}       -> {:ok, json}
+          {:error, reason}  -> {:error, %JSX.DecodeError{reason: reason, string: body} }
+        end
       {:error, reason} -> {:error, reason}
     end
   end

--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -12,10 +12,10 @@ defmodule Slack.Rtm do
 
   def start(token) do
     case HTTPoison.get(@url <> token) do
-      {:ok, %HTTPoison.Response{body: body} } ->
+      {:ok, %HTTPoison.Response{body: body}} ->
         case JSX.decode(body, [{:labels, :atom}]) do
           {:ok, json}       -> {:ok, json}
-          {:error, reason}  -> {:error, %JSX.DecodeError{reason: reason, string: body} }
+          {:error, reason}  -> {:error, %JSX.DecodeError{reason: reason, string: body}}
         end
       {:error, reason} -> {:error, reason}
     end


### PR DESCRIPTION
Fixes #45.

Took me about 30 requests to connect in a second to trigger, but now it won't let me make more than one a second, which is what the docs claim is the hard cap--so I guess they're pretty forgiving!