### PR TITLE
Lets Slack detect message confirmations if optional message ID is given.

### DIFF
--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -45,8 +45,11 @@ defmodule Slack do
 
   * `handle_connect(slack, state)` - called when connected to Slack.
   * `handle_event(message, slack, state)` - called when a message is received.
-  * `handle_close(reason, slack, state)` - called when websocket is closed before process is terminated.
-  * `handle_info(message, slack, state)` - called when any other message is received in the process mailbox.
+  * `handle_confirmation(confirmation, slack, state)` - called when a message
+     sent with an id has been confirmed as sent by Slack.
+  * `handle_close(reason, slack, state)` - called when websocket is closed.
+  * `handle_info(message, slack, state)` - called when any other message
+     is received in the process mailbox.
 
   ## Slack argument
 
@@ -81,10 +84,11 @@ defmodule Slack do
 
       def handle_connect(_slack, state), do: {:ok, state}
       def handle_event(_message, _slack, state), do: {:ok, state}
+      def handle_confirmation(_confirmation, _slack, state), do: {:ok, state}
       def handle_close(_reason, _slack, state), do: :close
       def handle_info(_message, _slack, state), do: {:ok, state}
 
-      defoverridable [handle_connect: 2, handle_event: 3, handle_close: 3, handle_info: 3]
+      defoverridable [handle_connect: 2, handle_event: 3, handle_confirmation: 3, handle_close: 3, handle_info: 3]
     end
   end
 end

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -81,7 +81,6 @@ defmodule Slack do
       import Slack.Lookups
       import Slack.Sends
 
-
       def handle_connect(_slack, state), do: {:ok, state}
       def handle_event(_message, _slack, state), do: {:ok, state}
       def handle_confirmation(_confirmation, _slack, state), do: {:ok, state}

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -21,6 +21,7 @@ defmodule Slack.Sends do
     end
   end
 
+
   def send_message(text, user = "@" <> _user_name, id, slack) do
     direct_message_id = Lookups.lookup_direct_message_id(user, slack)
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,11 +6,11 @@ defmodule Slack.Mixfile do
      version: "0.9.2",
      elixir: "~> 1.2",
      name: "Slack",
-     deps: deps,
-     docs: docs,
+     deps: deps(),
+     docs: docs(),
      source_url: "https://github.com/BlakeWilliams/Elixir-Slack",
      description: "A Slack Real Time Messaging API client.",
-     package: package]
+     package: package()]
   end
 
   def application do

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,6 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "pact": {:hex, :pact, "0.2.0"},
   "socket": {:git, "git://github.com/meh/elixir-socket.git", "ec03c935565dbe4708d6b594ef57d6de17a93592", []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
   "websocket_client": {:hex, :websocket_client, "1.1.0", "c1ac9162a2286d3ca747417b1717090e762becba1f9f0bde359cb0318b066636", [:rebar3], []}}

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -57,4 +57,8 @@ defmodule Slack.SendsTest do
     result = Sends.send_ping([foo: :bar], %{process: nil, client: FakeWebsocketClient})
     assert result == {nil, ~s/{"foo":"bar","type":"ping"}/}
   end
+
+  test "handle_confirmation returns state by default" do
+    assert Bot.handle_confirmation(nil, nil, 1) == {:ok, 1}
+  end
 end


### PR DESCRIPTION
This lets you provide an id to `send_message`, which will trigger Slack to return a confirmation when that message is posted. So it also adds a `handle_confirmation` callback so users can receive that information.

Closes #31, see discussion in #11.
