### PR TITLE
Remove state management from Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,14 @@ callback methods.
 defmodule SlackRtm do
   use Slack
 
-  def handle_connect(slack, state) do
+  def handle_connect(slack) do
     IO.puts "Connected as #{slack.me.name}"
-    {:ok, state}
   end
 
-  def handle_message(message = %{type: "message"}, slack, state) do
-    message_to_send = "Received #{length(state)} messages so far!"
-    send_message(message_to_send, message.channel, slack)
-
-    {:ok, state ++ [message.text]}
+  def handle_message(message = %{type: "message"}, slack) do
+    send_message("I got a message!", message.channel, slack)
   end
-
-  def handle_message(_message, _slack, state) do
-    {:ok, state}
-  end
+  def handle_message(_,_), do: :ok
 end
 ```
 
@@ -59,8 +52,8 @@ To run this example, you'll also want to call `SlackRtm.start_link("token", [])`
 and run the project with `mix run --no-halt`.
 
 You can send messages to channels using `send_message/3` which takes the message
-as the first argument, channel as the second, and the passed in `slack` state
-as the third.
+as the first argument, channel/user as the second, and the passed in `slack`
+state as the third.
 
 The passed in `slack` state holds the current user properties as `me`, team
 properties as `team`, the current websocket connection as `socket`, and a list

--- a/lib/slack/handlers.ex
+++ b/lib/slack/handlers.ex
@@ -9,78 +9,77 @@ defmodule Slack.Handlers do
   """
   @spec handle_slack(Map, Map) :: {Symbol, Map}
   def handle_slack(%{type: "channel_created", channel: channel}, slack) do
-    {:ok, put_in(slack, [:channels, channel.id], channel)}
+    put_in(slack, [:channels, channel.id], channel)
   end
 
   def handle_slack(%{type: "channel_joined", channel: channel}, slack) do
     slack = slack
     |> put_in([:channels, channel.id, :members], channel.members)
     |> put_in([:channels, channel.id, :is_member], true)
-    {:ok, slack}
   end
 
   def handle_slack(%{type: "group_joined", channel: channel}, slack) do
-    {:ok, put_in(slack, [:groups, channel.id], channel)}
+    put_in(slack, [:groups, channel.id], channel)
   end
 
   def handle_slack(%{type: "message", subtype: "channel_join", channel: channel, user: user}, slack) do
-    {:ok, put_in(slack, [:channels, channel, :members], [user | slack[:channels][channel][:members]])}
+    put_in(slack, [:channels, channel, :members], [user | slack[:channels][channel][:members]])
   end
 
   def handle_slack(%{type: "message", subtype: "group_join", channel: channel, user: user}, slack) do
-    {:ok, update_in(slack, [:groups, channel, :members], &(Enum.uniq([user | &1])))}
+    update_in(slack, [:groups, channel, :members], &(Enum.uniq([user | &1])))
   end
 
   def handle_slack(%{type: "channel_left", channel: channel_id}, slack) do
-    {:ok, put_in(slack, [:channels, channel_id, :is_member], false)}
+    put_in(slack, [:channels, channel_id, :is_member], false)
   end
 
   def handle_slack(%{type: "group_left", channel: channel}, slack) do
-    {:ok, update_in(slack, [:groups], &(Map.delete(&1, channel)))}
+    update_in(slack, [:groups], &(Map.delete(&1, channel)))
   end
 
   Enum.map(["channel", "group"], fn (type) ->
     plural_atom = String.to_atom(type <> "s")
 
     def handle_slack(%{type: unquote(type <> "_rename"), channel: channel}, slack) do
-      {:ok, put_in(slack, [unquote(plural_atom), channel.id, :name], channel.name)}
+      put_in(slack, [unquote(plural_atom), channel.id, :name], channel.name)
     end
     def handle_slack(%{type: unquote(type <> "_archive"), channel: channel}, slack) do
-      {:ok, put_in(slack, [unquote(plural_atom), channel, :is_archived], true)}
+      put_in(slack, [unquote(plural_atom), channel, :is_archived], true)
     end
     def handle_slack(%{type: unquote(type <> "_unarchive"), channel: channel}, slack) do
-      {:ok, put_in(slack, [unquote(plural_atom), channel, :is_archived], false)}
+      put_in(slack, [unquote(plural_atom), channel, :is_archived], false)
     end
     def handle_slack(%{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user}, slack) do
-      {:ok, update_in(slack, [unquote(plural_atom), channel, :members], &(&1 -- [user]))}
+      update_in(slack, [unquote(plural_atom), channel, :members], &(&1 -- [user]))
     end
   end)
 
   def handle_slack(%{type: "team_rename", name: name}, slack) do
-    {:ok, put_in(slack, [:team, :name], name)}
+    put_in(slack, [:team, :name], name)
   end
 
   def handle_slack(%{type: "presence_change", user: user, presence: presence}, slack) do
-    {:ok, put_in(slack, [:users, user, :presence], presence)}
+    put_in(slack, [:users, user, :presence], presence)
   end
-  
+
   Enum.map(["team_join", "user_change"], fn (type) ->
     def handle_slack(%{type: unquote(type), user: user}, slack) do
-      {:ok, put_in(slack, [:users, user.id], user)}
+      put_in(slack, [:users, user.id], user)
     end
   end)
 
   Enum.map(["bot_added", "bot_changed"], fn (type) ->
     def handle_slack(%{type: unquote(type), bot: bot}, slack) do
-      {:ok, put_in(slack, [:bots, bot.id], bot)}
+      put_in(slack, [:bots, bot.id], bot)
     end
   end)
 
   def handle_slack(%{type: "im_created", channel: channel}, slack) do
-    {:ok, put_in(slack, [:ims, channel.id], channel)}
+    put_in(slack, [:ims, channel.id], channel)
   end
 
   def handle_slack(%{type: _type}, slack) do
-    {:ok, slack}
+    slack
   end
 end

--- a/test/slack/handlers_test.exs
+++ b/test/slack/handlers_test.exs
@@ -3,7 +3,7 @@ defmodule Slack.HandlersTest do
   alias Slack.Handlers
 
   test "channel_joined sets is_member to true" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_joined", channel: %{id: "123", members: ["123456", "654321"]}},
       slack
     )
@@ -13,7 +13,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_left sets is_member to false" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_left", channel: "123"},
       slack
     )
@@ -22,7 +22,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_rename renames the channel" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_rename", channel: %{id: "123", name: "bar"}},
       slack
     )
@@ -31,7 +31,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_archive marks channel as archived" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_archive", channel: "123"},
       slack
     )
@@ -40,7 +40,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_unarchive marks channel as not archived" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_unarchive", channel: "123"},
       slack
     )
@@ -49,7 +49,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_leave marks channel as not archived" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "channel_unarchive", channel: "123"},
       slack
     )
@@ -58,7 +58,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "team_rename renames team" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "team_rename", name: "Bar"},
       slack
     )
@@ -68,7 +68,7 @@ defmodule Slack.HandlersTest do
 
   test "team_join adds user to users" do
     user_length = Map.size(slack.users)
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "team_join", user: %{id: "345"}},
       slack
     )
@@ -77,7 +77,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "user_change updates user" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "team_join", user: %{id: "123", name: "bar"}},
       slack
     )
@@ -88,7 +88,7 @@ defmodule Slack.HandlersTest do
   test "bot_added adds bot to bots" do
     bot_length = Map.size(slack.bots)
 
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "bot_added", bot: %{id: "345", name: "new"}},
       slack
     )
@@ -97,7 +97,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "bot_changed updates bot in bots" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "bot_added", bot: %{id: "123", name: "new"}},
       slack
     )
@@ -106,7 +106,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_join message should add member" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "message", subtype: "channel_join", user: "U456", channel: "123"},
       slack
     )
@@ -115,7 +115,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "channel_leave message should remove member" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "message", subtype: "channel_leave", user: "U123", channel: "123"},
       slack
     )
@@ -124,7 +124,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "presence_change message should update user" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{presence: "testing", type: "presence_change", user: "123"},
       slack
     )
@@ -133,7 +133,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "group_joined event should add group" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
       slack
     )
@@ -143,7 +143,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "group_join message should add user to member list" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
       slack
     )
@@ -152,7 +152,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "group_leave message should remove user from member list" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
       slack
     )
@@ -161,7 +161,7 @@ defmodule Slack.HandlersTest do
   end
 
   test "group_left message should remove group altogether" do
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "group_left", channel: "G000"},
       slack
     )
@@ -171,7 +171,7 @@ defmodule Slack.HandlersTest do
 
   test "im_created message should add direct message channel to list" do
     channel = %{name: "channel", id: "C456"}
-    {:ok, new_slack} = Handlers.handle_slack(
+    new_slack = Handlers.handle_slack(
       %{type: "im_created", channel: channel},
       slack
     )

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -5,14 +5,6 @@ defmodule SlackTest do
     use Slack
   end
 
-  test "on_connect returns state by default" do
-    assert Bot.handle_connect(nil, 1) == {:ok, 1}
-  end
-
-  test "handle_message returns state by default" do
-    assert Bot.handle_message(nil, nil, 1) == {:ok, 1}
-  end
-
   test "init formats rtm results properly" do
     rtm = %{
       self: %{name: "fake"},
@@ -24,7 +16,7 @@ defmodule SlackTest do
       ims: [%{id: "123"}]
     }
 
-    {:ok, %{slack: slack, state: state}} = Bot.init(%{rtm: rtm, state: 1, client: FakeWebsocketClient, token: "ABC"}, nil)
+    {:ok, slack} = Bot.init(%{rtm: rtm, client: FakeWebsocketClient, token: "ABC"}, nil)
 
     assert slack.me.name == "fake"
     assert slack.team.name == "Foo"
@@ -33,7 +25,5 @@ defmodule SlackTest do
     assert slack.groups   == %{"123" => %{id: "123"}}
     assert slack.users    == %{"123" => %{id: "123"}}
     assert slack.ims      == %{"123" => %{id: "123"}}
-
-    assert state == 1
   end
 end


### PR DESCRIPTION
Managing state for the user adds a good amount of complication to the
library in terms of maintaining and writing bots. This removes the state
management from Slack in favor of bot writers managing it themselves.

eg: The `Agent` module.