### PR TITLE
Clarified channel hash requirement in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ control Slack from your Elixir runtime:
 
 ```elixir
 {:ok, rtm} = SlackRtm.start_link("token")
-send rtm, {:message, "External message", "general"}
+send rtm, {:message, "External message", "#general"}
 #=> {:message, "External message", "#general"}
 #==> Sending your message, captain!
 ```


### PR DESCRIPTION
PR for issue discussed at: https://github.com/BlakeWilliams/Elixir-Slack/issues/71

Fixes the example for sending a message to a channel by name.