### PR TITLE
Use bots through module function calls

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -1,0 +1,142 @@
+defmodule Slack.Bot do
+  require Logger
+
+  @behaviour :websocket_client
+
+  @moduledoc """
+  This module is used to spawn bots and is used to manage the connection to Slack
+  while delegating events to the specified bot module.
+  """
+
+  @doc """
+  Connects to Slack and delegates events to `bot_handler`.
+
+  ## Example
+
+  Slack.Bot.start_link(MyBot, [1,2,3], "abc-123")
+  """
+  def start_link(bot_handler, initial_state, token, client \\ :websocket_client) do
+    case Slack.Rtm.start(token) do
+      {:ok, rtm} ->
+        state = %{
+          bot_handler: bot_handler,
+          rtm: rtm,
+          client: client,
+          token: token,
+          initial_state: initial_state
+        }
+        url = String.to_char_list(rtm.url)
+        client.start_link(url, __MODULE__, state, [keepalive: 10_000])
+      {:error, %HTTPoison.Error{reason: :connect_timeout}} ->
+        {:error, "Timed out while connecting to the Slack RTM API"}
+      {:error, %HTTPoison.Error{reason: :nxdomain}} ->
+        {:error, "Could not connect to the Slack RTM API"}
+      {:error, %JSX.DecodeError{string: "You are sending too many requests. Please relax."}} ->
+        {:error, "Sent too many connection requests at once to the Slack RTM API."}
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  # websocket_client API
+
+  @doc false
+  def init(%{bot_handler: bot_handler, rtm: rtm, client: client, token: token, initial_state: initial_state}) do
+    slack = %Slack.State{
+      process: self(),
+      client: client,
+      token: token,
+      me: rtm.self,
+      team: rtm.team,
+      bots: rtm_list_to_map(rtm.bots),
+      channels: rtm_list_to_map(rtm.channels),
+      groups: rtm_list_to_map(rtm.groups),
+      users: rtm_list_to_map(rtm.users),
+      ims: rtm_list_to_map(rtm.ims)
+    }
+
+    {:reconnect, %{slack: slack, bot_handler: bot_handler, process_state: initial_state}}
+  end
+
+  @doc false
+  def onconnect(_websocket_request, %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state) do
+    {:ok, new_process_state} = bot_handler.handle_connect(slack, process_state)
+    {:ok, %{state | process_state: new_process_state}}
+  end
+
+  @doc false
+  def ondisconnect(reason, %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state) do
+    try do
+      bot_handler.handle_close(reason, slack, process_state)
+      {:close, reason, state}
+    rescue
+      e ->
+        handle_exception(e)
+        {:close, reason, state}
+    end
+  end
+
+  @doc false
+  def websocket_info(message, _connection, %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state) do
+    new_process_state = if Map.has_key?(message, :type) do
+      try do
+        {:ok, new_process_state} = bot_handler.handle_info(message, slack, process_state)
+        new_process_state
+      rescue
+        e -> handle_exception(e)
+      end
+    else
+      process_state
+    end
+
+    {:ok, %{state | process_state: new_process_state}}
+  end
+
+  @doc false
+  def websocket_terminate(_reason, _conn, _state), do: :ok
+
+  @doc false
+  def websocket_handle({:text, message}, _conn, %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state) do
+    message = prepare_message message
+
+    updated_slack = if Map.has_key?(message, :type) do
+      Slack.State.update(message, slack)
+    else
+      slack
+    end
+
+    new_process_state = if Map.has_key?(message, :type) do
+      try do
+        {:ok, new_process_state} = bot_handler.handle_message(message, slack, process_state)
+        new_process_state
+      rescue
+        e -> handle_exception(e)
+      end
+    else
+      process_state
+    end
+
+    {:ok, %{state | slack: updated_slack, process_state: new_process_state}}
+  end
+  def websocket_handle(_, _conn, state), do: {:ok, state}
+
+  defp rtm_list_to_map(list) do
+    Enum.reduce(list, %{}, fn (item, map) ->
+      Map.put(map, item.id, item)
+    end)
+  end
+
+  defp prepare_message(binstring) do
+    binstring
+      |> :binary.split(<<0>>)
+      |> List.first
+      |> JSX.decode!([{:labels, :atom}])
+  end
+
+  defp handle_exception(e) do
+    message = Exception.message(e)
+    Logger.error(message)
+    System.stacktrace |> Exception.format_stacktrace |> Logger.error
+    raise message
+  end
+end

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -66,8 +66,8 @@ defmodule Slack.Sends do
   @doc """
   Sends raw JSON to a given socket.
   """
-  def send_raw(json, %{socket: socket, client: client}) do
-    client.send({:text, json}, socket)
+  def send_raw(json, %{process: pid, client: client}) do
+    client.cast(pid, {:text, json})
   end
 
   defp open_im_channel(token, user_id, on_success, on_error) do

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -8,7 +8,7 @@ defmodule Slack.State do
   defdelegate get_and_update(client, key, function), to: Map
 
   defstruct [
-    :socket,
+    :process,
     :client,
     :token,
     :me,

--- a/mix.exs
+++ b/mix.exs
@@ -14,13 +14,13 @@ defmodule Slack.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison, :hackney, :exjsx]]
+    [applications: [:logger, :httpoison, :hackney, :exjsx, :crypto]]
   end
 
   defp deps do
     [{:httpoison, "~> 0.9.0"},
      {:exjsx, "~> 3.2.0"},
-     {:websocket_client, github: "jeremyong/websocket_client", only: :dev},
+     {:websocket_client, "~> 1.1.0"},
      {:earmark, "~> 0.2.0", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -12,4 +12,4 @@
   "socket": {:git, "git://github.com/meh/elixir-socket.git", "ec03c935565dbe4708d6b594ef57d6de17a93592", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
-  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "48c118682292f2e4d80491161134a665525c4934", []}}
+  "websocket_client": {:hex, :websocket_client, "1.1.0", "c1ac9162a2286d3ca747417b1717090e762becba1f9f0bde359cb0318b066636", [:rebar3], []}}

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -1,0 +1,37 @@
+defmodule Slack.BotTest do
+  use ExUnit.Case
+
+  defmodule Bot do
+    use Slack
+  end
+
+  test "init formats rtm results properly" do
+    rtm = %{
+      self: %{name: "fake"},
+      team: %{name: "Foo"},
+      bots: [%{id: "123"}],
+      channels: [%{id: "123"}],
+      groups: [%{id: "123"}],
+      users: [%{id: "123"}],
+      ims: [%{id: "123"}]
+    }
+
+    {:reconnect, %{slack: slack, bot_handler: bot_handler}}
+      = Slack.Bot.init(%{
+          bot_handler: Bot,
+          rtm: rtm,
+          client: FakeWebsocketClient,
+          token: "ABC",
+          initial_state: nil,
+        })
+
+    assert bot_handler == Bot
+    assert slack.me.name == "fake"
+    assert slack.team.name == "Foo"
+    assert slack.bots     == %{"123" => %{id: "123"}}
+    assert slack.channels == %{"123" => %{id: "123"}}
+    assert slack.groups   == %{"123" => %{id: "123"}}
+    assert slack.users    == %{"123" => %{id: "123"}}
+    assert slack.ims      == %{"123" => %{id: "123"}}
+  end
+end

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -6,51 +6,55 @@ defmodule Slack.SendsTest do
     def send({:text, json}, socket) do
       {json, socket}
     end
+
+    def cast(pid, {:text, json}) do
+      {pid, json}
+    end
   end
 
   test "send_raw sends slack formatted to client" do
-    result = Sends.send_raw(~s/{"text": "foo"}/, %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"text": "foo"}/, nil}
+    result = Sends.send_raw(~s/{"text": "foo"}/, %{process: 123, client: FakeWebsocketClient})
+    assert result == {123, ~s/{"text": "foo"}/}
   end
 
   test "send_message sends message formatted to client" do
-    result = Sends.send_message("hello", "channel", %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"channel":"channel","text":"hello","type":"message"}/, nil}
+    result = Sends.send_message("hello", "channel", %{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"channel":"channel","text":"hello","type":"message"}/}
   end
 
   test "send_message understands #channel names" do
     slack = %{
-      socket: nil,
+      process: nil,
       client: FakeWebsocketClient,
       channels: %{"C456" => %{name: "channel", id: "C456"}}
     }
     result = Sends.send_message("hello", "#channel", slack)
-    assert result == {~s/{"channel":"C456","text":"hello","type":"message"}/, nil}
+    assert result == {nil, ~s/{"channel":"C456","text":"hello","type":"message"}/}
   end
 
   test "send_message understands @user names" do
     slack = %{
-      socket: nil,
+      process: nil,
       client: FakeWebsocketClient,
       users: %{"U123" => %{name: "user", id: "U123"}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
     result = Sends.send_message("hello", "@user", slack)
-    assert result == {~s/{"channel":"D789","text":"hello","type":"message"}/, nil}
+    assert result == {nil, ~s/{"channel":"D789","text":"hello","type":"message"}/}
   end
 
   test "indicate_typing sends typing notification to client" do
-    result = Sends.indicate_typing("channel", %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"channel":"channel","type":"typing"}/, nil}
+    result = Sends.indicate_typing("channel", %{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"channel":"channel","type":"typing"}/}
   end
 
   test "send_ping sends ping to client" do
-    result = Sends.send_ping(%{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"type":"ping"}/, nil}
+    result = Sends.send_ping(%{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"type":"ping"}/}
   end
 
   test "send_ping with data sends ping + data to client" do
-    result = Sends.send_ping([foo: :bar], %{socket: nil, client: FakeWebsocketClient})
-    assert result == {~s/{"foo":"bar","type":"ping"}/, nil}
+    result = Sends.send_ping([foo: :bar], %{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"foo":"bar","type":"ping"}/}
   end
 end

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -1,29 +1,3 @@
 defmodule SlackTest do
   use ExUnit.Case
-
-  defmodule Bot do
-    use Slack
-  end
-
-  test "init formats rtm results properly" do
-    rtm = %{
-      self: %{name: "fake"},
-      team: %{name: "Foo"},
-      bots: [%{id: "123"}],
-      channels: [%{id: "123"}],
-      groups: [%{id: "123"}],
-      users: [%{id: "123"}],
-      ims: [%{id: "123"}]
-    }
-
-    {:ok, slack} = Bot.init(%{rtm: rtm, client: FakeWebsocketClient, token: "ABC"}, nil)
-
-    assert slack.me.name == "fake"
-    assert slack.team.name == "Foo"
-    assert slack.bots     == %{"123" => %{id: "123"}}
-    assert slack.channels == %{"123" => %{id: "123"}}
-    assert slack.groups   == %{"123" => %{id: "123"}}
-    assert slack.users    == %{"123" => %{id: "123"}}
-    assert slack.ims      == %{"123" => %{id: "123"}}
-  end
 end


### PR DESCRIPTION
This changes a non-trivial amount of details about the implementation some
of which affect the public API.

* Uses hex hosted `websocket_client` which has a slightly improved API
 and removes the need to add the github dependency when using this lib
* Re-introduces state per bot which means `handle_*` functions now
 receive the state as an argument
* `start_link` now takes `initial_state` before the token

### TODO:

- [x] Fix tests
- [x] Make sure README is up to date and example works
- [x] Update documentation
- [x] Clean up bot function definitions