### PR TITLE
Fix issues with post_message on Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: elixir
 elixir:
   - 1.2.0
+  - 1.3.0
+  - 1.4.0
 env: MIX_ENV=test
 otp_release:
   - 18.1

--- a/lib/mix/tasks/update_slack_api.ex
+++ b/lib/mix/tasks/update_slack_api.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.UpdateSlackApi do
   def run(_) do
     try do
       System.cmd("git", ["clone", "https://github.com/slackhq/slack-api-docs", "#{@dir}/slack-api-docs"])
-      files
+      files()
       |> filter_json
       |> copy_files
     after

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -55,7 +55,7 @@ defmodule Slack.Sends do
   Notifies slack that the current `slack` user is typing in `channel`.
   """
   def send_ping(data \\ [], slack) do
-    [ type: "ping" ]
+    [type: "ping"]
       |> Keyword.merge(data)
       |> JSX.encode!
       |> send_raw(slack)

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -55,10 +55,8 @@ defmodule Slack.Sends do
   Notifies slack that the current `slack` user is typing in `channel`.
   """
   def send_ping(data \\ [], slack) do
-    %{
-      type: "ping"
-    }
-      |> Dict.merge(data)
+    [ type: "ping" ]
+      |> Keyword.merge(data)
       |> JSX.encode!
       |> send_raw(slack)
   end

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -29,7 +29,7 @@ defmodule Slack.Web.Documentation do
     documentation
     |> arguments
     |> Enum.reduce([], fn(var = {arg, _, _}, acc) ->
-      [{to_string(arg), var} | acc]
+      [{arg, var} | acc]
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Slack.Mixfile do
      version: "0.9.2",
      elixir: "~> 1.2",
      name: "Slack",
-     deps: deps,
-     docs: docs,
+     deps: deps(),
+     docs: docs(),
      source_url: "https://github.com/BlakeWilliams/Elixir-Slack",
      description: "A Slack Real Time Messaging API client.",
      package: package]

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Slack.Mixfile do
      docs: docs(),
      source_url: "https://github.com/BlakeWilliams/Elixir-Slack",
      description: "A Slack Real Time Messaging API client.",
-     package: package]
+     package: package()]
   end
 
   def application do

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -55,6 +55,6 @@ defmodule Slack.SendsTest do
 
   test "send_ping with data sends ping + data to client" do
     result = Sends.send_ping([foo: :bar], %{process: nil, client: FakeWebsocketClient})
-    assert result == {nil, ~s/{"foo":"bar","type":"ping"}/}
+    assert result == {nil, ~s/{"type":"ping","foo":"bar"}/}
   end
 end

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -5,7 +5,7 @@ defmodule Slack.StateTest do
   test "channel_joined sets is_member to true" do
     new_slack = State.update(
       %{type: "channel_joined", channel: %{id: "123", members: ["123456", "654321"]}},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].is_member == true

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -15,7 +15,7 @@ defmodule Slack.StateTest do
   test "channel_left sets is_member to false" do
     new_slack = State.update(
       %{type: "channel_left", channel: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].is_member == false
@@ -24,7 +24,7 @@ defmodule Slack.StateTest do
   test "channel_rename renames the channel" do
     new_slack = State.update(
       %{type: "channel_rename", channel: %{id: "123", name: "bar"}},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].name == "bar"
@@ -33,7 +33,7 @@ defmodule Slack.StateTest do
   test "channel_archive marks channel as archived" do
     new_slack = State.update(
       %{type: "channel_archive", channel: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].is_archived == true
@@ -42,7 +42,7 @@ defmodule Slack.StateTest do
   test "channel_unarchive marks channel as not archived" do
     new_slack = State.update(
       %{type: "channel_unarchive", channel: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].is_archived == false
@@ -51,7 +51,7 @@ defmodule Slack.StateTest do
   test "channel_leave marks channel as not archived" do
     new_slack = State.update(
       %{type: "channel_unarchive", channel: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].is_archived == false
@@ -60,17 +60,17 @@ defmodule Slack.StateTest do
   test "team_rename renames team" do
     new_slack = State.update(
       %{type: "team_rename", name: "Bar"},
-      slack
+      slack()
     )
 
     assert new_slack.team.name == "Bar"
   end
 
   test "team_join adds user to users" do
-    user_length = Map.size(slack.users)
+    user_length = Map.size(slack().users)
     new_slack = State.update(
       %{type: "team_join", user: %{id: "345"}},
-      slack
+      slack()
     )
 
     assert Map.size(new_slack.users) == user_length + 1
@@ -79,18 +79,18 @@ defmodule Slack.StateTest do
   test "user_change updates user" do
     new_slack = State.update(
       %{type: "team_join", user: %{id: "123", name: "bar"}},
-      slack
+      slack()
     )
 
     assert new_slack.users["123"].name == "bar"
   end
 
   test "bot_added adds bot to bots" do
-    bot_length = Map.size(slack.bots)
+    bot_length = Map.size(slack().bots)
 
     new_slack = State.update(
       %{type: "bot_added", bot: %{id: "345", name: "new"}},
-      slack
+      slack()
     )
 
     assert Map.size(new_slack.bots) == bot_length + 1
@@ -99,7 +99,7 @@ defmodule Slack.StateTest do
   test "bot_changed updates bot in bots" do
     new_slack = State.update(
       %{type: "bot_added", bot: %{id: "123", name: "new"}},
-      slack
+      slack()
     )
 
     assert new_slack.bots["123"].name == "new"
@@ -108,7 +108,7 @@ defmodule Slack.StateTest do
   test "channel_join message should add member" do
     new_slack = State.update(
       %{type: "message", subtype: "channel_join", user: "U456", channel: "123"},
-      slack
+      slack()
     )
 
     assert (new_slack.channels["123"].members |> Enum.sort) == ["U123", "U456"]
@@ -117,7 +117,7 @@ defmodule Slack.StateTest do
   test "channel_leave message should remove member" do
     new_slack = State.update(
       %{type: "message", subtype: "channel_leave", user: "U123", channel: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.channels["123"].members == []
@@ -126,7 +126,7 @@ defmodule Slack.StateTest do
   test "presence_change message should update user" do
     new_slack = State.update(
       %{presence: "testing", type: "presence_change", user: "123"},
-      slack
+      slack()
     )
 
     assert new_slack.users["123"].presence == "testing"
@@ -135,7 +135,7 @@ defmodule Slack.StateTest do
   test "group_joined event should add group" do
     new_slack = State.update(
       %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
-      slack
+      slack()
     )
 
     assert new_slack.groups["G123"]
@@ -145,7 +145,7 @@ defmodule Slack.StateTest do
   test "group_join message should add user to member list" do
     new_slack = State.update(
       %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
-      slack
+      slack()
     )
 
     assert Enum.member?(new_slack.groups["G000"][:members], "U000")
@@ -154,7 +154,7 @@ defmodule Slack.StateTest do
   test "group_leave message should remove user from member list" do
     new_slack = State.update(
       %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
-      slack
+      slack()
     )
 
     refute Enum.member?(new_slack.groups["G000"].members, "U111")
@@ -163,7 +163,7 @@ defmodule Slack.StateTest do
   test "group_left message should remove group altogether" do
     new_slack = State.update(
       %{type: "group_left", channel: "G000"},
-      slack
+      slack()
     )
 
     refute new_slack.groups["G000"]
@@ -173,7 +173,7 @@ defmodule Slack.StateTest do
     channel = %{name: "channel", id: "C456"}
     new_slack = State.update(
       %{type: "im_created", channel: channel},
-      slack
+      slack()
     )
 
     assert new_slack.ims == %{"C456" => channel}

--- a/test/slack/web/documentation_test.exs
+++ b/test/slack/web/documentation_test.exs
@@ -1,0 +1,11 @@
+defmodule Slack.Web.DocumentationTest do
+  use ExUnit.Case
+  alias Slack.Web.Documentation
+
+  test "it returns a proper keyword list" do
+    doc = %Documentation{required_params: [:channel, :text]}
+
+    argument_value_keyword_list = Documentation.arguments_with_values(doc)
+    assert argument_value_keyword_list === [text: {:text, [], nil}, channel: {:channel, [], nil}]
+  end
+end


### PR DESCRIPTION
# Problem
`Slack.Web.Chat.post_message/3` does not work when upgrading elixir to 1.4. Here is the error we get:
```elixir
iex(1)> Slack.Web.Chat.post_message("test_channel", "hello")
** (ArgumentError) expected a keyword list as the second argument, got: [{"text", "hello"}, {"channel", "test_channel"}]
    (elixir) lib/keyword.ex:589: Keyword.merge/2
     (slack) lib/slack/web/web.ex:44: Slack.Web.Chat.post_message/3
```

# Cause
This is happening because of https://github.com/elixir-lang/elixir/pull/5466. 
In
```elixir
params = optional_params
        |> Map.to_list
        |> Keyword.merge(required_params)
        |> Keyword.put_new(:token, Application.get_env(:slack, :api_token))
```
 `required_params` passed to `Keyword.merge` is not a `Keyword` and because of the latest changes in Elixir, `Keyword.merge` will raise error if passed arguments are not keyword lists.

# Solution
I modified `arguments_with_values` in `Documentation` module to create a keyword list which basically means instead of use string for first item, use symbol. So in the error above we have ```
```
[{"text", "hello"}, {"channel", "test_channel"}]
```
Is now
```
[{:text, "hello"}, {:channel, "test_channel"}]
```

# Other changes
Did some cleanup to avoid elixir compile warnings and also removed usages of `Dict.map` which is now deprecated.

Let me know if these changes makes sense.