### PR TITLE
Fix library to work with Elixir v1.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: elixir
-elixir:
-  - 1.2.0
-  - 1.3.0
-  - 1.4.0
-env: MIX_ENV=test
-otp_release:
-  - 18.1
+matrix:
+  include:
+    - otp_release: 18.1
+      elixir: 1.2.0
+      env: MIX_ENV=test
+    - otp_release: 19.2
+      elixir: 1.4.0
+      env: MIX_ENV=test
 after_success:
   - mix coveralls.travis

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -29,7 +29,7 @@ defmodule Slack.Web.Documentation do
     documentation
     |> arguments
     |> Enum.reduce([], fn(var = {arg, _, _}, acc) ->
-      [{arg, var} | acc]
+      [{String.to_atom(to_string(arg)), var} | acc]
     end)
   end
 

--- a/test/slack/web/documentation_test.exs
+++ b/test/slack/web/documentation_test.exs
@@ -2,10 +2,10 @@ defmodule Slack.Web.DocumentationTest do
   use ExUnit.Case
   alias Slack.Web.Documentation
 
-  test "it returns a proper keyword list" do
-    doc = %Documentation{required_params: [:channel, :text]}
+  test "that Documentation.arguments_with_values/1 returns a proper keyword list" do
+    doc = %Documentation{required_params: [:channel]}
 
     argument_value_keyword_list = Documentation.arguments_with_values(doc)
-    assert argument_value_keyword_list === [text: {:text, [], nil}, channel: {:channel, [], nil}]
+    assert [channel: {:channel, [], nil}] == argument_value_keyword_list
   end
 end


### PR DESCRIPTION
Why:

* Keyword.merge/2 in Elixir versions previous to v1.4.0 did not require
  the second argument to be a Keyword list.
  Slack.Web.Documentation.arguments_with_values\1 does not return a
  KeywordList which then causes issues when Keyword.merge/2 is called in
  generated functions for Slack.Web.

This change addresses the need by:

* Add test coverage for Slack.Web.Documentation.arguments_with_values\1
* Call String.to_atom\1 Slack.Web.Documentation.arguments_with_values\1

Side effects:

* The library should no longer crash on elixir v1.4.0 due to calling
  KeywordList.merge\2 with a List.