### PR TITLE
Fix warnings for Elixir v1.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: elixir
-elixir:
-  - 1.2.0
-  - 1.3.0
-  - 1.4.0
-env: MIX_ENV=test
-otp_release:
-  - 18.1
+matrix:
+  include:
+    - otp_release: 18.1
+      elixir: 1.2.0
+      env: MIX_ENV=test
+    - otp_release: 18.1
+      elixir: 1.3.0
+      env: MIX_ENV=test
+    - otp_release: 19.2
+      elixir: 1.4.0
+      env: MIX_ENV=test
 after_success:
   - mix coveralls.travis

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -54,9 +54,11 @@ defmodule Slack.Sends do
   @doc """
   Notifies slack that the current `slack` user is typing in `channel`.
   """
-  def send_ping(data \\ [], slack) do
-    [type: "ping"]
-      |> Keyword.merge(data)
+  def send_ping(data \\ %{}, slack) do
+    %{
+      type: "ping"
+    }
+      |> Map.merge(Map.new(data))
       |> JSX.encode!
       |> send_raw(slack)
   end

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -4,8 +4,14 @@ defmodule Slack.State do
   def fetch(client, key)
   defdelegate fetch(client, key), to: Map
 
+  def get(client, key, default)
+  defdelegate get(client, key, default), to: Map
+
   def get_and_update(client, key, function)
   defdelegate get_and_update(client, key, function), to: Map
+
+  def pop(client, key)
+  defdelegate pop(client, key), to: Map
 
   defstruct [
     :process,

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -54,7 +54,7 @@ defmodule Slack.SendsTest do
   end
 
   test "send_ping with data sends ping + data to client" do
-    result = Sends.send_ping([foo: :bar], %{process: nil, client: FakeWebsocketClient})
-    assert result == {nil, ~s/{"type":"ping","foo":"bar"}/}
+    result = Sends.send_ping(%{foo: :bar}, %{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"foo":"bar","type":"ping"}/}
   end
 end


### PR DESCRIPTION
Why:

* Nullary functions without parenthesis cause warnings.
* Access behaviour warns about missing get and pop functions.
* Dict.merge/2 is deprecated.

This change addresses the need by:

* Add parenthesis to nullary functions.
* Delegate get and pop to Map for Slack.State.
* Refactor Slack.Sends.send_ping/2 to use Map.merge/2 instead of
  Dict.merge/2.

Side effects:

* There should be no side effects.