### PR TITLE
Add fake slack and integration test simple bot

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule Slack.Mixfile do
     [app: :slack,
      version: "0.14.0",
      elixir: "~> 1.2",
+     elixirc_paths: elixirc_paths(Mix.env),
      name: "Slack",
      deps: deps(),
      docs: docs(),
@@ -12,6 +13,9 @@ defmodule Slack.Mixfile do
      description: "A Slack Real Time Messaging API client.",
      package: package()]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   def application do
     [applications: [:logger, :httpoison, :hackney, :crypto, :websocket_client]]
@@ -23,7 +27,9 @@ defmodule Slack.Mixfile do
      {:poison, "~> 3.0"},
      {:earmark, "~> 0.2.0", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev},
-     {:credo, "~> 0.5", only: [:dev, :test]}
+     {:credo, "~> 0.5", only: [:dev, :test]},
+     {:plug, "~> 1.3", only: :test},
+     {:cowboy, "~> 1.0.0", only: :test}
    ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "1.1.0", "c9b71a547016c2528a590ccfc28de786c7edb74aafa17446b84f54e04efc00ee", [:rebar3], []},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
@@ -7,10 +10,14 @@
   "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [:mix], [{:hackney, "~> 1.8.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "pact": {:hex, :pact, "0.2.0"},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
   "socket": {:git, "git://github.com/meh/elixir-socket.git", "ec03c935565dbe4708d6b594ef57d6de17a93592", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
-  "websocket_client": {:hex, :websocket_client, "1.2.4", "14ec1ca4b6d247b44ccd9a80af8f6ca98328070f6c1d52a5cb00bc9d939d63b8", [:rebar3], []}}
+  "websocket_client": {:hex, :websocket_client, "1.2.4", "14ec1ca4b6d247b44ccd9a80af8f6ca98328070f6c1d52a5cb00bc9d939d63b8", [:rebar3], []},
+}

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -49,7 +49,11 @@ defmodule Slack.BotTest do
   end
 
   test "can configure the RTM module" do
+    original_slack_rtm = Application.get_env(:slack, :rtm_module, Slack.Rtm)
+
     Application.put_env(:slack, :rtm_module, Stubs.Slack.Rtm)
     assert {:ok, _pid} = Slack.Bot.start_link(Bot, %{}, "token", %{client: Stubs.Slack.WebsocketClient})
+
+    Application.put_env(:slack, :rtm_module, original_slack_rtm)
   end
 end

--- a/test/integration/bot_test.exs
+++ b/test/integration/bot_test.exs
@@ -1,0 +1,61 @@
+defmodule Slack.Integration.BotTest do
+  use ExUnit.Case, async: false
+
+  defmodule Bot do
+    use Slack
+
+    def handle_event(message = %{type: "message", text: text}, slack, state) do
+      send_message(String.reverse(text), message.channel, slack)
+      {:ok, state}
+    end
+    def handle_event(_, _, state), do: {:ok, state}
+  end
+
+  setup_all do
+    Slack.FakeSlack.start_link()
+
+    on_exit fn ->
+      Slack.FakeSlack.stop()
+    end
+  end
+
+  test "can connect and respond" do
+    Application.put_env(:slack, :test_pid, self())
+    {:ok, _pid} =  Slack.Bot.start_link(Bot, [], "xyz")
+
+    assert authenticated_with_token?("xyz")
+
+    websocket_pid = get_websocket_pid()
+
+    send_message_to_client(websocket_pid, "hello!")
+    assert bot_sent_message?("!olleh")
+  end
+
+  defp authenticated_with_token?(token) do
+    receive do
+      {:token, ^token} -> true
+    after
+      100 -> false
+    end
+  end
+
+  defp get_websocket_pid do
+    receive do
+      {:websocket_connected, websocket_pid} -> websocket_pid
+    after
+      100 -> false
+    end
+  end
+
+  defp bot_sent_message?(text) do
+    receive do
+      {:bot_message, %{"text" => ^text}} -> true
+    after
+      100 -> false
+    end
+  end
+
+  defp send_message_to_client(pid, message) do
+    send pid, Poison.encode!(%{type: "message", text: message, channel: "C0123abc"})
+  end
+end

--- a/test/support/fake_slack.ex
+++ b/test/support/fake_slack.ex
@@ -1,12 +1,12 @@
 defmodule Slack.FakeSlack do
   def start_link do
+    Application.put_env(:slack, :url, "http://localhost:51345")
     Plug.Adapters.Cowboy.http(
       Slack.FakeSlack.Router,
       [],
       port: 51345,
       dispatch: dispatch()
     )
-    Application.put_env(:slack, :url, "http://localhost:51345")
   end
 
   def stop do

--- a/test/support/fake_slack.ex
+++ b/test/support/fake_slack.ex
@@ -1,0 +1,25 @@
+defmodule Slack.FakeSlack do
+  def start_link do
+    Plug.Adapters.Cowboy.http(
+      Slack.FakeSlack.Router,
+      [],
+      port: 51345,
+      dispatch: dispatch()
+    )
+    Application.put_env(:slack, :url, "http://localhost:51345")
+  end
+
+  def stop do
+    Plug.Adapters.Cowboy.shutdown(Slack.FakeSlack.Router)
+  end
+
+  defp dispatch do
+    [{
+      :_,
+      [
+        {"/ws", Slack.FakeSlack.Websocket, []},
+        {:_, Plug.Adapters.Cowboy.Handler, {Slack.FakeSlack.Router, []}}
+      ]
+    }]
+  end
+end

--- a/test/support/fake_slack/router.ex
+++ b/test/support/fake_slack/router.ex
@@ -1,0 +1,30 @@
+defmodule Slack.FakeSlack.Router do
+  use Plug.Router
+  import Plug.Conn
+
+  plug :match
+  plug :dispatch
+
+  get "/api/rtm.start" do
+    conn = fetch_query_params(conn)
+
+    pid = Application.get_env(:slack, :test_pid)
+    send pid, {:token, conn.query_params["token"]}
+
+    response = ~S(
+      {
+        "ok": true,
+        "url": "ws://localhost:51345/ws",
+        "self": { "id": "U0123abcd", "name": "bot" },
+        "team": { "id": "T4567abcd", "name": "Example Team" },
+        "bots": [{ "id": "U0123abcd", "name": "bot" }],
+        "channels": [],
+        "groups": [],
+        "users": [],
+        "ims": []
+      }
+    )
+
+    send_resp(conn, 200, response)
+  end
+end

--- a/test/support/fake_slack/websocket.ex
+++ b/test/support/fake_slack/websocket.ex
@@ -1,0 +1,37 @@
+defmodule Slack.FakeSlack.Websocket do
+  @behaviour :cowboy_websocket_handler
+
+  def init(_, _req, _opts) do
+    {:upgrade, :protocol, :cowboy_websocket}
+  end
+
+  @activity_timeout 5000
+
+  def websocket_init(_type, req, _opts) do
+    state = %{}
+
+    pid = Application.get_env(:slack, :test_pid)
+    send pid, {:websocket_connected, self()}
+
+    {:ok, req, state, @activity_timeout}
+  end
+
+  def websocket_handle({:text, "ping"}, req, state) do
+    {:reply, {:text, "pong"}, req, state}
+  end
+
+  def websocket_handle({:text, message}, req, state) do
+    pid = Application.get_env(:slack, :test_pid)
+    send pid, {:bot_message, Poison.decode!(message)}
+
+    {:ok, req, state}
+  end
+
+  def websocket_info(message, req, state) do
+    {:reply, {:text, message}, req, state}
+  end
+
+  def websocket_terminate(_reason, _req, _state) do
+    :ok
+  end
+end


### PR DESCRIPTION
This adds a `Slack.FakeSlack` module that spins up a cowboy server that serves a fake [`rtm.start`](https://api.slack.com/methods/rtm.start) endpoint and a websocket interface that the bot can connect to and send/receive messages to/from.

This also adds a simple test taking advantage of the new `FakeSlack` module.

This should resolve #112 