### PR TITLE
Handle RTM failure scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: elixir
 matrix:
   include:
     - otp_release: 18.1
-      elixir: 1.2.0
-      env: MIX_ENV=test
-    - otp_release: 18.1
       elixir: 1.3.0
       env: MIX_ENV=test
     - otp_release: 19.2

--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -21,6 +21,7 @@ defmodule Slack.Rtm do
         {:ok, json}
     else
       {:error, reason} -> {:error, %JSX.DecodeError{reason: reason, string: body}}
+      %{error: reason} -> {:error, "Slack API returned an error `#{reason}.\n Response: #{body}"}
       _ -> {:error, "Invalid RTM response"}
     end
   end


### PR DESCRIPTION
The slack API provides a key for checking if the response was successful for not. This PR adds a check for `ok: true` in the API response