### PR TITLE
Remove `nil` valued keywords from params

### DIFF
--- a/lib/slack/web/web.ex
+++ b/lib/slack/web/web.ex
@@ -46,6 +46,7 @@ Enum.each(Slack.Web.get_documentation, fn({module_name, functions}) ->
         |> Map.to_list
         |> Keyword.merge(required_params)
         |> Keyword.put_new(:token, Application.get_env(:slack, :api_token))
+        |> Enum.reject(fn {k, v} -> v == nil end)
 
         %{body: body} = HTTPoison.post!(
           "#{url}/api/#{unquote(doc.endpoint)}",


### PR DESCRIPTION
When calling `Slack.Web.Oauth.access/3`, a `nil` token is used causing the Oauth flow to fail with an `invalid_auth` error. Removing `nil` valued keywords fixes the issue.