### PR TITLE
Handle websocket keepalive timeout with reconnect

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -83,6 +83,10 @@ defmodule Slack.Bot do
   end
 
   @doc false
+  def ondisconnect({:error, :keepalive_timeout}, state) do
+    {:reconnect, state}
+  end
+
   def ondisconnect(reason, %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state) do
     try do
       bot_handler.handle_close(reason, slack, process_state)


### PR DESCRIPTION
Fixes #120.

Add ondisconnect function head that matches keepalive timeout
and reconnects rather than crashing. Retain original behavior for
all other disconnect reasons.