### PR TITLE
Allow send_message/3 to accept a user ID

### DIFF
--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -16,6 +16,10 @@ defmodule Slack.Sends do
       raise ArgumentError, "channel ##{channel_name} not found"
     end
   end
+  def send_message(text, user_id = "U" <> _user_id, slack) do
+    user_name = Slack.Lookups.lookup_user_name(user_id, slack)
+    send_message(text, user_name, slack)
+  end
   def send_message(text, user = "@" <> _user_name, slack) do
     direct_message_id = Lookups.lookup_direct_message_id(user, slack)
 

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -43,6 +43,17 @@ defmodule Slack.SendsTest do
     assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
   end
 
+  test "send_message understands user ids (Uxxx)" do
+    slack = %{
+      process: nil,
+      client: FakeWebsocketClient,
+      users: %{"U123" => %{name: "user", id: "U123"}},
+      ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+    result = Sends.send_message("hello", "U123", slack)
+    assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
+  end
+
   test "indicate_typing sends typing notification to client" do
     result = Sends.indicate_typing("channel", %{process: nil, client: FakeWebsocketClient})
     assert result == {nil, ~s/{"type":"typing","channel":"channel"}/}


### PR DESCRIPTION
I ran in to an issue in my app where I was trying to use `send_message/3` with a slack user ID and was getting silent failures. I dug around the source and realized I need to use `@user_name` instead. I had to dig around a bit to discover the `Slack.Lookups` module and use something like `user = Slack.Lookups.lookup_user_name(user_id, slack)` to send a messages. I ran in to this because my app is storing slack user IDs and *initiating* conversations, so I'm not just responding to inbound message where the user name / channel is already present.