### PR TITLE
use poison package with version 3.0.0 or above

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Slack.Mixfile do
   defp deps do
     [{:httpoison, "~> 0.11"},
      {:websocket_client, "~> 1.2.4"},
-     {:poison, "~> 3.0"},
+     {:poison, ">= 3.0.0"},
      {:earmark, "~> 0.2.0", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev},
      {:credo, "~> 0.5", only: [:dev, :test]}

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Slack.Mixfile do
   defp deps do
     [{:httpoison, "~> 0.11"},
      {:websocket_client, "~> 1.2.4"},
-     {:poison, ">= 3.0.0"},
+     {:poison, "> 2.9.9"},
      {:earmark, "~> 0.2.0", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev},
      {:credo, "~> 0.5", only: [:dev, :test]}


### PR DESCRIPTION
Since we have `poison` is very widely used package, we need to use its minimum version instead of using the exact version. So used `:poison, ">= 3.0.0"` instead so that this package does not have error for that exact version while installing hex packages.