### PR TITLE
Update to deal with changed presence tracking.

### DIFF
--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -26,6 +26,6 @@ defmodule Slack.Rtm do
   defp handle_response(error), do: error
 
   defp slack_url(token) do
-    Application.get_env(:slack, :url, "https://slack.com") <> "/api/rtm.start?token=#{token}"
+    Application.get_env(:slack, :url, "https://slack.com") <> "/api/rtm.start?token=#{token}&batch_presence_aware=true&presence_sub=true"
   end
 end

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -69,6 +69,18 @@ defmodule Slack.Sends do
   end
 
   @doc """
+  Subscribe to presence notifications for the user IDs in `ids`.
+  """
+  def subscribe_presence(ids \\ [], slack) do
+    %{
+      type: "presence_sub",
+      ids: ids
+    }
+      |> Poison.encode!()
+      |> send_raw(slack)
+  end
+
+  @doc """
   Sends raw JSON to a given socket.
   """
   def send_raw(json, %{process: pid, client: client}) do

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -86,6 +86,12 @@ defmodule Slack.State do
     put_in(slack, [:users, user, :presence], presence)
   end
 
+  def update(%{type: "presence_change", users: users, presence: presence}, slack) do
+    Enum.reduce(users, slack, fn(user, acc) ->
+      put_in(acc, [:users, user, :presence], presence)
+    end)
+  end
+
   def update(%{type: "team_join", user: user}, slack) do
     put_in(slack, [:users, user.id], user)
   end

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -68,4 +68,14 @@ defmodule Slack.SendsTest do
     result = Sends.send_ping(%{foo: :bar}, %{process: nil, client: FakeWebsocketClient})
     assert result == {nil, ~s/{"type":"ping","foo":"bar"}/}
   end
+
+  test "subscribe_presence sends presence subscription message to client" do
+    result = Sends.subscribe_presence(["a_user_id"], %{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"type":"presence_sub","ids":["a_user_id"]}/}
+  end
+
+  test "subscribe_presence without ids sends presence subscription message to client" do
+    result = Sends.subscribe_presence(%{process: nil, client: FakeWebsocketClient})
+    assert result == {nil, ~s/{"type":"presence_sub","ids":[]}/}
+  end
 end

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -133,6 +133,16 @@ defmodule Slack.StateTest do
     assert new_slack.users["123"].presence == "testing"
   end
 
+  test "bulk presence_change message should update users" do
+    new_slack = State.update(
+      %{presence: "testing", type: "presence_change", users: ["123", "U2"]},
+      slack()
+    )
+
+    assert new_slack.users["123"].presence == "testing"
+    assert new_slack.users["U2"].presence == "testing"
+  end
+
   test "group_joined event should add group" do
     new_slack = State.update(
       %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
@@ -198,6 +208,10 @@ defmodule Slack.StateTest do
         "123" => %{
           name: "Bar",
           presence: "active"
+        },
+        "U2" => %{
+          name: "Baz",
+          presence: "away"
         }
       },
       groups: %{


### PR DESCRIPTION
Presence change tracking has changed in slack (see
https://api.slack.com/docs/presence-and-status#batching)

This change updates us to tell slack that we understand the new
presence processing messages, and updates us to handle them properly.

Presence data will still not be supplied to clients until the client
subscribes to presence notifications, so this change also adds a
function to make that a bit more convenient.