### PR TITLE
Don't discard presence data when a user is changed

### DIFF
--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -86,11 +86,13 @@ defmodule Slack.State do
     put_in(slack, [:users, user, :presence], presence)
   end
 
-  Enum.map(["team_join", "user_change"], fn (type) ->
-    def update(%{type: unquote(type), user: user}, slack) do
-      put_in(slack, [:users, user.id], user)
-    end
-  end)
+  def update(%{type: "team_join", user: user}, slack) do
+    put_in(slack, [:users, user.id], user)
+  end
+
+  def update(%{type: "user_change", user: user}, slack) do
+    put_in(slack, [:users, user.id], Map.merge(slack.users[user.id], user))
+  end
 
   Enum.map(["bot_added", "bot_changed"], fn (type) ->
     def update(%{type: unquote(type), bot: bot}, slack) do

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -78,11 +78,12 @@ defmodule Slack.StateTest do
 
   test "user_change updates user" do
     new_slack = State.update(
-      %{type: "team_join", user: %{id: "123", name: "bar"}},
+      %{type: "user_change", user: %{id: "123", name: "bar"}},
       slack()
     )
 
     assert new_slack.users["123"].name == "bar"
+    assert new_slack.users["123"].presence == "active"
   end
 
   test "bot_added adds bot to bots" do
@@ -98,7 +99,7 @@ defmodule Slack.StateTest do
 
   test "bot_changed updates bot in bots" do
     new_slack = State.update(
-      %{type: "bot_added", bot: %{id: "123", name: "new"}},
+      %{type: "bot_changed", bot: %{id: "123", name: "new"}},
       slack()
     )
 


### PR DESCRIPTION
The `user_change` event does not include presence data, so if we just
replace the user in `slack.users`, then we lose any presence data we've
stored for that user.

Also updates a test where we were testing the wrong message type.