### PR TITLE
Handle receiving a user_change message when the user is not in state

### DIFF
--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -97,10 +97,7 @@ defmodule Slack.State do
   end
 
   def update(%{type: "user_change", user: user}, slack) do
-    user = Map.get(slack.users, user.id, %{})
-    |> Map.merge(user)
-
-    put_in(slack, [:users, user.id], user)
+    update_in(slack, [:users, Access.key(user.id, %{})], &Map.merge(&1, user))
   end
 
   Enum.map(["bot_added", "bot_changed"], fn (type) ->

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -97,7 +97,10 @@ defmodule Slack.State do
   end
 
   def update(%{type: "user_change", user: user}, slack) do
-    put_in(slack, [:users, user.id], Map.merge(slack.users[user.id], user))
+    user = Map.get(slack.users, user.id, %{})
+    |> Map.merge(user)
+
+    put_in(slack, [:users, user.id], user)
   end
 
   Enum.map(["bot_added", "bot_changed"], fn (type) ->

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -190,6 +190,32 @@ defmodule Slack.StateTest do
     assert new_slack.ims == %{"C456" => channel}
   end
 
+  test "user_change merges an existing user" do
+    user = %{id: "123", presence: "away", nickname: "Baz"}
+    new_slack = State.update(
+      %{type: "user_change", user: user},
+      slack()
+    )
+    assert new_slack.users["123"] == %{
+      id: "123",
+      name: "Bar",
+      presence: "away",
+      nickname: "Baz"
+    }
+  end
+  test "user_change adds a new user" do
+    user = %{id: "345", presence: "active", name: "Bar"}
+    new_slack = State.update(
+      %{type: "user_change", user: user},
+      slack()
+    )
+    assert new_slack.users["345"] == %{
+      id: "345",
+      name: "Bar",
+      presence: "active"
+    }
+  end
+
   defp slack do
     %{
       channels: %{


### PR DESCRIPTION
I have hit several crashes in my slack application upon processing a `user_change` message. Upon further inspection, it is because there is no existing user in the state map when the message is processed. 

That is to say,
slac.users[user.id] is null, so Map.merge(null, %{}) returns a badmap exception.

This PR fixes this case by defaulting the user to the empty map when merging in the new state. I have added tests for this case as well.