### PR TITLE
Fix two bugs related to sending message to non-existing user

### DIFF
--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -7,7 +7,7 @@ defmodule Slack.Lookups do
   def lookup_user_id("@" <> user_name, slack) do
     slack.users
     |> Map.values
-    |> Enum.find(%{}, fn user -> user.name == user_name or user.profile.display_name == user_name end)
+    |> Enum.find(%{}, fn user -> user.name == user_name || user.profile.display_name == user_name end)
     |> Map.get(:id)
   end
 

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -7,7 +7,7 @@ defmodule Slack.Lookups do
   def lookup_user_id("@" <> user_name, slack) do
     slack.users
     |> Map.values
-    |> Enum.find(%{}, fn user -> user.name == user_name end)
+    |> Enum.find(%{}, fn user -> user.name == user_name or user.profile.display_name == user_name end)
     |> Map.get(:id)
   end
 

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -30,7 +30,7 @@ defmodule Slack.Sends do
         slack.token,
         Lookups.lookup_user_id(user, slack),
         fn id -> send_message(text, id, slack) end,
-        fn _reason -> :delivery_failed end
+        fn reason -> reason end
       )
     end
   end
@@ -98,7 +98,7 @@ defmodule Slack.Sends do
       {:ok, response} ->
         case Poison.Parser.parse!(response.body, keys: :atoms) do
           %{ok: true, channel: %{id: id}} -> on_success.(id)
-          _ -> on_error.()
+          e = %{error: error_message} -> on_error.(e)
         end
       {:error, reason} -> on_error.(reason)
     end

--- a/test/slack/lookups_test.exs
+++ b/test/slack/lookups_test.exs
@@ -3,13 +3,13 @@ defmodule Slack.LookupsTest do
   alias Slack.Lookups
 
   test "turns @user into a user identifier" do
-    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    slack = %{users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}}}
     assert Lookups.lookup_user_id("@user", slack) == "U123"
   end
 
   test "turns @user into direct message identifier, if the channel exists" do
     slack = %{
-      users: %{"U123" => %{name: "user", id: "U123"}},
+      users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
     assert Lookups.lookup_direct_message_id("@user", slack) == "D789"
@@ -44,13 +44,13 @@ defmodule Slack.LookupsTest do
   end
 
   test "turns a user identifier into @user" do
-    slack = %{users: %{"U123" => %{name: "user", id: "U123"}}}
+    slack = %{users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}}}
     assert Lookups.lookup_user_name("U123", slack) == "@user"
   end
 
   test "turns a direct message identifier into @user" do
     slack = %{
-      users: %{"U123" => %{name: "user", id: "U123"}},
+      users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
     assert Lookups.lookup_user_name("D789", slack) == "@user"


### PR DESCRIPTION
1. user id lookup was not checking for display_name
2. open_im_channel had a simple arity bug