### PR TITLE
Add configurable web http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ names = Slack.Web.Users.list(%{token: "TOKEN_HERE"})
 end)
 ```
 
+### Web Client Configuration
+
+A custom client callback module can be configured for cases in which you need extra control
+over how calls to the web API are performed. This can be used to control timeouts, or to add additional
+custom error handling as needed.
+
+```elixir
+config :slack, :web_http_client, YourApp.CustomClient
+```
+
+All Web API calls from documenation-generated modules/functions will call `post!/2` with the generated url
+and body passed as arguments.
+
+In the case where you only need to control the options passed to HTTPoison/hackney, the default client accepts
+a keyword list as an additional configuration parameter. Note that this is ignored if configuring a custom client.
+
+See [HTTPoison docs](https://hexdocs.pm/httpoison/HTTPoison.html#request/5) for a list of avilable options.
+
+```elixir
+config :slack, :web_http_client_opts, [timeout: 10_000, recv_timeout: 10_000]
+```
+
+
 ## Testing
 
 For integration tests, you can change the default Slack URL to your fake Slack

--- a/lib/slack/web/client.ex
+++ b/lib/slack/web/client.ex
@@ -1,0 +1,28 @@
+defmodule Slack.Web.Client do
+  @moduledoc """
+  Default http client used for all requests to web API.
+
+  All Slack RPC method calls are delivered via post and are dangerous by
+  default, raising on any HTTP response that doesn't contain a body field.
+
+  Parsed body data is returned unwrapped to the caller.
+
+  Additional error handling or response wrapping can be controlled as needed
+  by configuring a custom client module.
+
+  ```
+  config :slack, :web_http_client, YourApp.CustomClient
+  ```
+  """
+
+  def post!(url, body) do
+    url
+    |> HTTPoison.post!(body, [], opts())
+    |> Map.fetch!(:body)
+    |> Poison.Parser.parse!()
+  end
+
+  defp opts do
+    Application.get_env(:slack, :web_http_client_opts, [])
+  end
+end

--- a/lib/slack/web/web.ex
+++ b/lib/slack/web/web.ex
@@ -43,19 +43,21 @@ Enum.each(Slack.Web.get_documentation, fn({module_name, functions}) ->
         url = Application.get_env(:slack, :url, "https://slack.com")
 
         params = optional_params
-        |> Map.to_list
+        |> Map.to_list()
         |> Keyword.merge(required_params)
         |> Keyword.put_new(:token, get_token(optional_params))
         |> Enum.reject(fn {_, v} -> v == nil end)
 
-        %{body: body} = HTTPoison.post!(
+        perform!(
           "#{url}/api/#{unquote(doc.endpoint)}",
           params(unquote(function_name), params, unquote(arguments))
         )
-
-        Poison.Parser.parse!(body)
       end
     end)
+
+    defp perform!(url, body) do
+      Application.get_env(:slack, :web_http_client, Slack.Web.Client).post!(url, body)
+    end
 
     defp get_token(%{token: token}), do: token
     defp get_token(_), do: Application.get_env(:slack, :api_token)


### PR DESCRIPTION
A while ago I opened #141, suggesting that I think there is a need to make some breaking API changes for the web API in order to better handle errors and to provide additional configuration. I still think this is the right move, but haven't had the chance to spend the time thinking through the new API design.

With Slack's somewhat recent migration to the OpenAPI standard for their docs, the current state of the generated modules/functions is probably a bit up in the air, and if there is going to be breaking change made it certainly makes sense to consider what the migration strategy might be there. I had a go a using a swagger generator based on the docs, but what it generated was not something I was particularly happy with.

This PR is an incremental change that will provide users of the web API with an a straightforward way to inject their own matching, handling, logging and configuration into API calls and responses without needed to understand the current macros. It's backwards compatible with what was is place before, and will solve a pain point for me of providing an easy way to control the timeout config of the API calls, which have started to cause problems with me in a production app.

As per usual, I'm happy to have some feedback from @BlakeWilliams or others.