### PR TITLE
Update bot.ex docs

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -14,10 +14,14 @@ defmodule Slack.Bot do
   ## Options
 
   * `keepalive` - How long to wait for the connection to respond before the client kills the connection.
+  * `name` - registers a name for the process with the given atom
 
   ## Example
 
-  Slack.Bot.start_link(MyBot, [1,2,3], "abc-123")
+  {:ok, pid} = Slack.Bot.start_link(MyBot, [1,2,3], "abc-123", %{name: :slack_bot})
+  
+  :sys.get_state(:slack_bot)
+  
   """
   def start_link(bot_handler, initial_state, token, options \\ %{}) do
     options = Map.merge(%{


### PR DESCRIPTION
For my app, I just needed one process running for the Slack bot. For conveniences in my code I wanted to simply call `send(:slack_bot, {:message, "hello world", "#channel"})` rather than use a Registry or keep track of a pid. I think this addition would other people as it took me a bit of time to figure out naming a Slack.Bot process.