### PR TITLE
switch out deprecated function

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -41,7 +41,7 @@ defmodule Slack.Bot do
           initial_state: initial_state
         }
 
-        url = String.to_char_list(state.rtm.url)
+        url = String.to_charlist(state.rtm.url)
         {:ok, pid} = options.client.start_link(url, __MODULE__, state, [keepalive: options.keepalive])
 
         if options.name != nil do


### PR DESCRIPTION
The current code generates this warning: 

`warning: String.to_char_list/1 is deprecated, use String.to_charlist/1`

So let's just swap this out, very easy to change