### PR TITLE
Format codebase using Elixir's autoformatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/mix/tasks/update_slack_api.exs
+++ b/lib/mix/tasks/update_slack_api.exs
@@ -2,11 +2,16 @@ defmodule Mix.Tasks.UpdateSlackApi do
   @moduledoc "Updates Slack API documentation files for generating API code"
 
   use Mix.Task
-  @dir System.tmp_dir
+  @dir System.tmp_dir()
 
   def run(_) do
     try do
-      System.cmd("git", ["clone", "https://github.com/slackhq/slack-api-docs", "#{@dir}/slack-api-docs"])
+      System.cmd("git", [
+        "clone",
+        "https://github.com/slackhq/slack-api-docs",
+        "#{@dir}/slack-api-docs"
+      ])
+
       list_files()
       |> filter_json
       |> copy_files
@@ -20,14 +25,15 @@ defmodule Mix.Tasks.UpdateSlackApi do
   end
 
   defp filter_json(files) do
-    Enum.filter(files, fn(file) ->
+    Enum.filter(files, fn file ->
       String.ends_with?(file, "json")
     end)
   end
 
   defp copy_files(files) do
     File.mkdir_p!("lib/slack/web/docs")
-    Enum.map(files, fn(file) ->
+
+    Enum.map(files, fn file ->
       origin = "#{@dir}slack-api-docs/methods/#{file}"
       dest = "lib/slack/web/docs/#{file}"
       File.cp!(origin, dest)

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -78,13 +78,12 @@ defmodule Slack do
       import Slack.Lookups
       import Slack.Sends
 
-
       def handle_connect(_slack, state), do: {:ok, state}
       def handle_event(_message, _slack, state), do: {:ok, state}
       def handle_close(_reason, _slack, state), do: :close
       def handle_info(_message, _slack, state), do: {:ok, state}
 
-      defoverridable [handle_connect: 2, handle_event: 3, handle_close: 3, handle_info: 3]
+      defoverridable handle_connect: 2, handle_event: 3, handle_close: 3, handle_info: 3
     end
   end
 end

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -6,8 +6,10 @@ defmodule Slack.Lookups do
   """
   def lookup_user_id("@" <> user_name, slack) do
     slack.users
-    |> Map.values
-    |> Enum.find(%{}, fn user -> user.name == user_name || user.profile.display_name == user_name end)
+    |> Map.values()
+    |> Enum.find(%{}, fn user ->
+      user.name == user_name || user.profile.display_name == user_name
+    end)
     |> Map.get(:id)
   end
 
@@ -21,9 +23,10 @@ defmodule Slack.Lookups do
     |> lookup_user_id(slack)
     |> lookup_direct_message_id(slack)
   end
+
   def lookup_direct_message_id(user_id, slack) do
     slack.ims
-    |> Map.values
+    |> Map.values()
     |> Enum.find(%{}, fn direct_message -> direct_message.user == user_id end)
     |> Map.get(:id)
   end
@@ -34,9 +37,10 @@ defmodule Slack.Lookups do
   (`"G…"`) if a group/private channel.
   """
   def lookup_channel_id("#" <> channel_name, slack) do
-    channel = find_channel_by_name(slack.channels, channel_name)
-      || find_channel_by_name(slack.groups, channel_name)
-      || %{}
+    channel =
+      find_channel_by_name(slack.channels, channel_name) ||
+        find_channel_by_name(slack.groups, channel_name) || %{}
+
     Map.get(channel, :id)
   end
 
@@ -47,9 +51,11 @@ defmodule Slack.Lookups do
   def lookup_user_name(direct_message_id = "D" <> _id, slack) do
     lookup_user_name(slack.ims[direct_message_id].user, slack)
   end
+
   def lookup_user_name(user_id = "U" <> _id, slack) do
     "@" <> slack.users[user_id].name
   end
+
   def lookup_user_name(bot_id = "B" <> _id, slack) do
     "@" <> slack.bots[bot_id].name
   end

--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -19,15 +19,24 @@ defmodule Slack.Rtm do
 
   defp handle_response({:ok, %HTTPoison.Response{body: body}}) do
     case Poison.Parser.parse(body, keys: :atoms) do
-      {:ok, %{ok: true} = json} -> {:ok, json}
-      {:ok, %{error: reason}} -> {:error, "Slack API returned an error `#{reason}.\n Response: #{body}"}
-      {:error, reason} -> {:error, %Slack.JsonDecodeError{reason: reason, string: body}}
-      _ -> {:error, "Invalid RTM response"}
+      {:ok, %{ok: true} = json} ->
+        {:ok, json}
+
+      {:ok, %{error: reason}} ->
+        {:error, "Slack API returned an error `#{reason}.\n Response: #{body}"}
+
+      {:error, reason} ->
+        {:error, %Slack.JsonDecodeError{reason: reason, string: body}}
+
+      _ ->
+        {:error, "Invalid RTM response"}
     end
   end
+
   defp handle_response(error), do: error
 
   defp slack_url(token) do
-    Application.get_env(:slack, :url, "https://slack.com") <> "/api/rtm.start?token=#{token}&batch_presence_aware=true&presence_sub=true"
+    Application.get_env(:slack, :url, "https://slack.com") <>
+      "/api/rtm.start?token=#{token}&batch_presence_aware=true&presence_sub=true"
   end
 end

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -16,10 +16,12 @@ defmodule Slack.Sends do
       raise ArgumentError, "channel ##{channel_name} not found"
     end
   end
+
   def send_message(text, user_id = "U" <> _user_id, slack) do
     user_name = Slack.Lookups.lookup_user_name(user_id, slack)
     send_message(text, user_name, slack)
   end
+
   def send_message(text, user = "@" <> _user_name, slack) do
     direct_message_id = Lookups.lookup_direct_message_id(user, slack)
 
@@ -34,14 +36,15 @@ defmodule Slack.Sends do
       )
     end
   end
+
   def send_message(text, channel, slack) do
     %{
       type: "message",
       text: text,
       channel: channel
     }
-      |> Poison.encode!()
-      |> send_raw(slack)
+    |> Poison.encode!()
+    |> send_raw(slack)
   end
 
   @doc """
@@ -52,8 +55,8 @@ defmodule Slack.Sends do
       type: "typing",
       channel: channel
     }
-      |> Poison.encode!()
-      |> send_raw(slack)
+    |> Poison.encode!()
+    |> send_raw(slack)
   end
 
   @doc """
@@ -63,9 +66,9 @@ defmodule Slack.Sends do
     %{
       type: "ping"
     }
-      |> Map.merge(Map.new(data))
-      |> Poison.encode!()
-      |> send_raw(slack)
+    |> Map.merge(Map.new(data))
+    |> Poison.encode!()
+    |> send_raw(slack)
   end
 
   @doc """
@@ -76,8 +79,8 @@ defmodule Slack.Sends do
       type: "presence_sub",
       ids: ids
     }
-      |> Poison.encode!()
-      |> send_raw(slack)
+    |> Poison.encode!()
+    |> send_raw(slack)
   end
 
   @doc """
@@ -90,17 +93,21 @@ defmodule Slack.Sends do
   defp open_im_channel(token, user_id, on_success, on_error) do
     url = Application.get_env(:slack, :url, "https://slack.com")
 
-    im_open = HTTPoison.post(
-      url <> "/api/im.open",
-      {:form, [token: token, user: user_id]}
-    )
+    im_open =
+      HTTPoison.post(
+        url <> "/api/im.open",
+        {:form, [token: token, user: user_id]}
+      )
+
     case im_open do
       {:ok, response} ->
         case Poison.Parser.parse!(response.body, keys: :atoms) do
           %{ok: true, channel: %{id: id}} -> on_success.(id)
           e = %{error: error_message} -> on_error.(e)
         end
-      {:error, reason} -> on_error.(reason)
+
+      {:error, reason} ->
+        on_error.(reason)
     end
   end
 end

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -50,7 +50,7 @@ defmodule Slack.State do
   end
 
   def update(%{type: "message", subtype: "group_join", channel: channel, user: user}, slack) do
-    update_in(slack, [:groups, channel, :members], &(Enum.uniq([user | &1])))
+    update_in(slack, [:groups, channel, :members], &Enum.uniq([user | &1]))
   end
 
   def update(%{type: "channel_left", channel: channel_id}, slack) do
@@ -58,22 +58,28 @@ defmodule Slack.State do
   end
 
   def update(%{type: "group_left", channel: channel}, slack) do
-    update_in(slack, [:groups], &(Map.delete(&1, channel)))
+    update_in(slack, [:groups], &Map.delete(&1, channel))
   end
 
-  Enum.map(["channel", "group"], fn (type) ->
+  Enum.map(["channel", "group"], fn type ->
     plural_atom = String.to_atom(type <> "s")
 
     def update(%{type: unquote(type <> "_rename"), channel: channel}, slack) do
       put_in(slack, [unquote(plural_atom), channel.id, :name], channel.name)
     end
+
     def update(%{type: unquote(type <> "_archive"), channel: channel}, slack) do
       put_in(slack, [unquote(plural_atom), channel, :is_archived], true)
     end
+
     def update(%{type: unquote(type <> "_unarchive"), channel: channel}, slack) do
       put_in(slack, [unquote(plural_atom), channel, :is_archived], false)
     end
-    def update(%{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user}, slack) do
+
+    def update(
+          %{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user},
+          slack
+        ) do
       update_in(slack, [unquote(plural_atom), channel, :members], &(&1 -- [user]))
     end
   end)
@@ -87,7 +93,7 @@ defmodule Slack.State do
   end
 
   def update(%{type: "presence_change", users: users, presence: presence}, slack) do
-    Enum.reduce(users, slack, fn(user, acc) ->
+    Enum.reduce(users, slack, fn user, acc ->
       put_in(acc, [:users, user, :presence], presence)
     end)
   end
@@ -100,7 +106,7 @@ defmodule Slack.State do
     update_in(slack, [:users, Access.key(user.id, %{})], &Map.merge(&1, user))
   end
 
-  Enum.map(["bot_added", "bot_changed"], fn (type) ->
+  Enum.map(["bot_added", "bot_changed"], fn type ->
     def update(%{type: unquote(type), bot: bot}, slack) do
       put_in(slack, [:bots, bot.id], bot)
     end

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -1,60 +1,74 @@
 defmodule Slack.Web.Documentation do
   @moduledoc false
 
-  defstruct [:endpoint, :module, :function, :desc, :required_params,
-    :optional_params, :errors, :raw]
+  defstruct [
+    :endpoint,
+    :module,
+    :function,
+    :desc,
+    :required_params,
+    :optional_params,
+    :errors,
+    :raw
+  ]
 
   def new(documentation, file_name) do
-    [module_name, function_name] = String.replace(file_name, ".json", "")
-    |> String.split(".", parts: 2)
+    [module_name, function_name] =
+      String.replace(file_name, ".json", "")
+      |> String.split(".", parts: 2)
 
     %__MODULE__{
       module: module_name,
       endpoint: "#{module_name}.#{function_name}",
-      function: function_name |> Macro.underscore |> String.to_atom,
+      function: function_name |> Macro.underscore() |> String.to_atom(),
       desc: documentation["desc"],
       required_params: get_required_params(documentation),
       optional_params: get_optional_params(documentation),
       errors: documentation["errors"],
-      raw: documentation,
+      raw: documentation
     }
   end
 
   def arguments(documentation) do
     documentation.required_params
-    |> Enum.map(&(Macro.var(&1, nil)))
+    |> Enum.map(&Macro.var(&1, nil))
   end
 
   def arguments_with_values(documentation) do
     documentation
     |> arguments
-    |> Enum.reduce([], fn(var = {arg, _, _}, acc) ->
+    |> Enum.reduce([], fn var = {arg, _, _}, acc ->
       [{arg, var} | acc]
     end)
   end
 
   def to_doc_string(documentation) do
-    Enum.join([
-      documentation.desc,
-      required_params_docs(documentation),
-      optional_params_docs(documentation),
-      errors_docs(documentation),
-    ], "\n")
+    Enum.join(
+      [
+        documentation.desc,
+        required_params_docs(documentation),
+        optional_params_docs(documentation),
+        errors_docs(documentation)
+      ],
+      "\n"
+    )
   end
 
   defp required_params_docs(%__MODULE__{required_params: []}), do: ""
+
   defp required_params_docs(documentation) do
     get_param_docs_for(documentation, :required_params, "Required Params")
   end
 
   defp optional_params_docs(%__MODULE__{optional_params: []}), do: ""
+
   defp optional_params_docs(documentation) do
     get_param_docs_for(documentation, :optional_params, "Optional Params")
   end
 
   defp get_param_docs_for(documentation, field, title) do
     Map.get(documentation, field)
-    |> Enum.reduce("\n#{title}\n", fn(param, doc) ->
+    |> Enum.reduce("\n#{title}\n", fn param, doc ->
       meta = get_in(documentation.raw, ["args", to_string(param)])
       doc <> "* `#{param}` - #{meta["desc"]} #{example(meta)}\n"
     end)
@@ -63,12 +77,14 @@ defmodule Slack.Web.Documentation do
   def example(%{"example" => example}) do
     "ex: `#{example}`"
   end
+
   def example(_meta), do: ""
 
   defp errors_docs(%__MODULE__{errors: nil}), do: ""
+
   defp errors_docs(%__MODULE__{errors: errors}) do
     errors
-    |> Enum.reduce("\nErrors the API can return:\n", fn({error, desc}, doc) ->
+    |> Enum.reduce("\nErrors the API can return:\n", fn {error, desc}, doc ->
       doc <> "* `#{error}` - #{desc}\n"
     end)
   end
@@ -78,17 +94,18 @@ defmodule Slack.Web.Documentation do
 
   defp get_params_with_required(%{"args" => args}, required) do
     args
-    |> Enum.filter(fn({_, meta}) ->
+    |> Enum.filter(fn {_, meta} ->
       if required do
         meta["required"]
       else
         !meta["required"]
       end
     end)
-    |> Enum.map(fn({name, _meta}) ->
-      name |> String.to_atom
+    |> Enum.map(fn {name, _meta} ->
+      name |> String.to_atom()
     end)
   end
+
   defp get_params_with_required(_json, _required) do
     []
   end

--- a/lib/slack/web/web.ex
+++ b/lib/slack/web/web.ex
@@ -7,7 +7,7 @@ defmodule Slack.Web do
   end
 
   defp format_documentation(files) do
-    Enum.reduce(files, %{}, fn(file, module_names) ->
+    Enum.reduce(files, %{}, fn file, module_names ->
       json =
         File.read!("#{__DIR__}/docs/#{file}")
         |> Poison.Parser.parse!()
@@ -23,12 +23,12 @@ end
 
 alias Slack.Web.Documentation
 
-Enum.each(Slack.Web.get_documentation, fn({module_name, functions}) ->
-  module_name = module_name |> Macro.camelize
+Enum.each(Slack.Web.get_documentation(), fn {module_name, functions} ->
+  module_name = module_name |> Macro.camelize()
   module = Module.concat(Slack.Web, module_name)
 
   defmodule module do
-    Enum.each(functions, fn(doc) ->
+    Enum.each(functions, fn doc ->
       function_name = doc.function
 
       arguments = Documentation.arguments(doc)
@@ -42,11 +42,12 @@ Enum.each(Slack.Web.get_documentation, fn({module_name, functions}) ->
 
         url = Application.get_env(:slack, :url, "https://slack.com")
 
-        params = optional_params
-        |> Map.to_list()
-        |> Keyword.merge(required_params)
-        |> Keyword.put_new(:token, get_token(optional_params))
-        |> Enum.reject(fn {_, v} -> v == nil end)
+        params =
+          optional_params
+          |> Map.to_list()
+          |> Keyword.merge(required_params)
+          |> Keyword.put_new(:token, get_token(optional_params))
+          |> Enum.reject(fn {_, v} -> v == nil end)
 
         perform!(
           "#{url}/api/#{unquote(doc.endpoint)}",
@@ -64,12 +65,15 @@ Enum.each(Slack.Web.get_documentation, fn({module_name, functions}) ->
 
     defp params(:upload, params, arguments) do
       file = List.first(arguments)
-      params = Enum.map(params, fn({key, value}) ->
-        {"", to_string(value), {"form-data", [{"name", key}]}, []}
-      end)
+
+      params =
+        Enum.map(params, fn {key, value} ->
+          {"", to_string(value), {"form-data", [{"name", key}]}, []}
+        end)
 
       {:multipart, params ++ [{:file, file, []}]}
     end
+
     defp params(_, params, _), do: {:form, params}
   end
 end)

--- a/mix.exs
+++ b/mix.exs
@@ -2,34 +2,37 @@ defmodule Slack.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :slack,
-     version: "0.15.0",
-     elixir: "~> 1.2",
-     elixirc_paths: elixirc_paths(Mix.env),
-     name: "Slack",
-     deps: deps(),
-     docs: docs(),
-     source_url: "https://github.com/BlakeWilliams/Elixir-Slack",
-     description: "A Slack Real Time Messaging API client.",
-     package: package()]
+    [
+      app: :slack,
+      version: "0.15.0",
+      elixir: "~> 1.2",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      name: "Slack",
+      deps: deps(),
+      docs: docs(),
+      source_url: "https://github.com/BlakeWilliams/Elixir-Slack",
+      description: "A Slack Real Time Messaging API client.",
+      package: package()
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [applications: [:logger, :httpoison, :hackney, :crypto, :websocket_client]]
   end
 
   defp deps do
-    [{:httpoison, "~> 1.2"},
-     {:websocket_client, "~> 1.2.4"},
-     {:poison, "~> 3.0"},
-     {:ex_doc, "~> 0.19", only: :dev},
-     {:credo, "~> 0.5", only: [:dev, :test]},
-     {:plug, "~> 1.6", only: :test},
-     {:cowboy, "~> 1.0.0", only: :test}
-   ]
+    [
+      {:httpoison, "~> 1.2"},
+      {:websocket_client, "~> 1.2.4"},
+      {:poison, "~> 3.0"},
+      {:ex_doc, "~> 0.19", only: :dev},
+      {:credo, "~> 0.5", only: [:dev, :test]},
+      {:plug, "~> 1.6", only: :test},
+      {:cowboy, "~> 1.0.0", only: :test}
+    ]
   end
 
   def docs do
@@ -37,10 +40,13 @@ defmodule Slack.Mixfile do
   end
 
   defp package do
-    %{maintainers: ["Blake Williams"],
+    %{
+      maintainers: ["Blake Williams"],
       licenses: ["MIT"],
       links: %{
-        "Github": "https://github.com/BlakeWilliams/Elixir-Slack",
-        "Documentation": "http://hexdocs.pm/slack/"}}
+        Github: "https://github.com/BlakeWilliams/Elixir-Slack",
+        Documentation: "http://hexdocs.pm/slack/"
+      }
+    }
   end
 end

--- a/test/bot_test.exs
+++ b/test/bot_test.exs
@@ -17,23 +17,23 @@ defmodule Slack.BotTest do
   }
 
   test "init formats rtm results properly" do
-    {:reconnect, %{slack: slack, bot_handler: bot_handler}}
-      = Slack.Bot.init(%{
-          bot_handler: Bot,
-          rtm: @rtm,
-          client: FakeWebsocketClient,
-          token: "ABC",
-          initial_state: nil,
-        })
+    {:reconnect, %{slack: slack, bot_handler: bot_handler}} =
+      Slack.Bot.init(%{
+        bot_handler: Bot,
+        rtm: @rtm,
+        client: FakeWebsocketClient,
+        token: "ABC",
+        initial_state: nil
+      })
 
     assert bot_handler == Bot
     assert slack.me.name == "fake"
     assert slack.team.name == "Foo"
-    assert slack.bots     == %{"123" => %{id: "123"}}
+    assert slack.bots == %{"123" => %{id: "123"}}
     assert slack.channels == %{"123" => %{id: "123"}}
-    assert slack.groups   == %{"123" => %{id: "123"}}
-    assert slack.users    == %{"123" => %{id: "123"}}
-    assert slack.ims      == %{"123" => %{id: "123"}}
+    assert slack.groups == %{"123" => %{id: "123"}}
+    assert slack.users == %{"123" => %{id: "123"}}
+    assert slack.ims == %{"123" => %{id: "123"}}
   end
 
   defmodule Stubs.Slack.Rtm do
@@ -52,7 +52,9 @@ defmodule Slack.BotTest do
     original_slack_rtm = Application.get_env(:slack, :rtm_module, Slack.Rtm)
 
     Application.put_env(:slack, :rtm_module, Stubs.Slack.Rtm)
-    assert {:ok, _pid} = Slack.Bot.start_link(Bot, %{}, "token", %{client: Stubs.Slack.WebsocketClient})
+
+    assert {:ok, _pid} =
+             Slack.Bot.start_link(Bot, %{}, "token", %{client: Stubs.Slack.WebsocketClient})
 
     Application.put_env(:slack, :rtm_module, original_slack_rtm)
   end

--- a/test/integration/bot_test.exs
+++ b/test/integration/bot_test.exs
@@ -8,20 +8,21 @@ defmodule Slack.Integration.BotTest do
       send_message(String.reverse(text), message.channel, slack)
       {:ok, state}
     end
+
     def handle_event(_, _, state), do: {:ok, state}
   end
 
   setup_all do
     Slack.FakeSlack.start_link()
 
-    on_exit fn ->
+    on_exit(fn ->
       Slack.FakeSlack.stop()
-    end
+    end)
   end
 
   test "can connect and respond" do
     Application.put_env(:slack, :test_pid, self())
-    {:ok, _pid} =  Slack.Bot.start_link(Bot, [], "xyz")
+    {:ok, _pid} = Slack.Bot.start_link(Bot, [], "xyz")
 
     assert authenticated_with_token?("xyz")
 
@@ -56,6 +57,6 @@ defmodule Slack.Integration.BotTest do
   end
 
   defp send_message_to_client(pid, message) do
-    send pid, Poison.encode!(%{type: "message", text: message, channel: "C0123abc"})
+    send(pid, Poison.encode!(%{type: "message", text: message, channel: "C0123abc"}))
   end
 end

--- a/test/slack/lookups_test.exs
+++ b/test/slack/lookups_test.exs
@@ -12,6 +12,7 @@ defmodule Slack.LookupsTest do
       users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
+
     assert Lookups.lookup_direct_message_id("@user", slack) == "D789"
     assert Lookups.lookup_direct_message_id("@missing", slack) == nil
   end
@@ -30,16 +31,18 @@ defmodule Slack.LookupsTest do
   test "turns private #channel into a group identifier" do
     slack = %{
       channels: %{},
-      groups:   %{"G456" => %{name: "private", id: "G456"}}
+      groups: %{"G456" => %{name: "private", id: "G456"}}
     }
+
     assert Lookups.lookup_channel_id("#private", slack) == "G456"
   end
 
   test "turns unknown #channel into nil" do
     slack = %{
       channels: %{},
-      groups:   %{}
+      groups: %{}
     }
+
     assert Lookups.lookup_channel_id("#unknown", slack) == nil
   end
 
@@ -53,6 +56,7 @@ defmodule Slack.LookupsTest do
       users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
+
     assert Lookups.lookup_user_name("D789", slack) == "@user"
   end
 
@@ -64,8 +68,9 @@ defmodule Slack.LookupsTest do
   test "turns a private channel identifier into #channel" do
     slack = %{
       channels: %{},
-      groups:   %{"G456" => %{name: "channel", id: "G456"}}
+      groups: %{"G456" => %{name: "channel", id: "G456"}}
     }
+
     assert Lookups.lookup_channel_name("G456", slack) == "#channel"
   end
 end

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -28,6 +28,7 @@ defmodule Slack.SendsTest do
       client: FakeWebsocketClient,
       channels: %{"C456" => %{name: "channel", id: "C456"}}
     }
+
     result = Sends.send_message("hello", "#channel", slack)
     assert result == {nil, ~s/{"type":"message","text":"hello","channel":"C456"}/}
   end
@@ -39,6 +40,7 @@ defmodule Slack.SendsTest do
       users: %{"U123" => %{name: "user", id: "U123"}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
+
     result = Sends.send_message("hello", "@user", slack)
     assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
   end
@@ -50,6 +52,7 @@ defmodule Slack.SendsTest do
       users: %{"U123" => %{name: "user", id: "U123"}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
     }
+
     result = Sends.send_message("hello", "U123", slack)
     assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
   end

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -3,84 +3,94 @@ defmodule Slack.StateTest do
   alias Slack.State
 
   test "channel_joined sets is_member to true" do
-    new_slack = State.update(
-      %{type: "channel_joined", channel: %{id: "123", members: ["123456", "654321"]}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_joined", channel: %{id: "123", members: ["123456", "654321"]}},
+        slack()
+      )
 
     assert new_slack.channels["123"].is_member == true
     assert new_slack.channels["123"].members == ["123456", "654321"]
   end
 
   test "channel_left sets is_member to false" do
-    new_slack = State.update(
-      %{type: "channel_left", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_left", channel: "123"},
+        slack()
+      )
 
     assert new_slack.channels["123"].is_member == false
   end
 
   test "channel_rename renames the channel" do
-    new_slack = State.update(
-      %{type: "channel_rename", channel: %{id: "123", name: "bar"}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_rename", channel: %{id: "123", name: "bar"}},
+        slack()
+      )
 
     assert new_slack.channels["123"].name == "bar"
   end
 
   test "channel_archive marks channel as archived" do
-    new_slack = State.update(
-      %{type: "channel_archive", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_archive", channel: "123"},
+        slack()
+      )
 
     assert new_slack.channels["123"].is_archived == true
   end
 
   test "channel_unarchive marks channel as not archived" do
-    new_slack = State.update(
-      %{type: "channel_unarchive", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_unarchive", channel: "123"},
+        slack()
+      )
 
     assert new_slack.channels["123"].is_archived == false
   end
 
   test "channel_leave marks channel as not archived" do
-    new_slack = State.update(
-      %{type: "channel_unarchive", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "channel_unarchive", channel: "123"},
+        slack()
+      )
 
     assert new_slack.channels["123"].is_archived == false
   end
 
   test "team_rename renames team" do
-    new_slack = State.update(
-      %{type: "team_rename", name: "Bar"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "team_rename", name: "Bar"},
+        slack()
+      )
 
     assert new_slack.team.name == "Bar"
   end
 
   test "team_join adds user to users" do
     user_length = Map.size(slack().users)
-    new_slack = State.update(
-      %{type: "team_join", user: %{id: "345"}},
-      slack()
-    )
+
+    new_slack =
+      State.update(
+        %{type: "team_join", user: %{id: "345"}},
+        slack()
+      )
 
     assert Map.size(new_slack.users) == user_length + 1
   end
 
   test "user_change updates user" do
-    new_slack = State.update(
-      %{type: "user_change", user: %{id: "123", name: "bar"}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "user_change", user: %{id: "123", name: "bar"}},
+        slack()
+      )
 
     assert new_slack.users["123"].name == "bar"
     assert new_slack.users["123"].presence == "active"
@@ -89,131 +99,150 @@ defmodule Slack.StateTest do
   test "bot_added adds bot to bots" do
     bot_length = Map.size(slack().bots)
 
-    new_slack = State.update(
-      %{type: "bot_added", bot: %{id: "345", name: "new"}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "bot_added", bot: %{id: "345", name: "new"}},
+        slack()
+      )
 
     assert Map.size(new_slack.bots) == bot_length + 1
   end
 
   test "bot_changed updates bot in bots" do
-    new_slack = State.update(
-      %{type: "bot_changed", bot: %{id: "123", name: "new"}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "bot_changed", bot: %{id: "123", name: "new"}},
+        slack()
+      )
 
     assert new_slack.bots["123"].name == "new"
   end
 
   test "channel_join message should add member" do
-    new_slack = State.update(
-      %{type: "message", subtype: "channel_join", user: "U456", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "message", subtype: "channel_join", user: "U456", channel: "123"},
+        slack()
+      )
 
-    assert (new_slack.channels["123"].members |> Enum.sort) == ["U123", "U456"]
+    assert new_slack.channels["123"].members |> Enum.sort() == ["U123", "U456"]
   end
 
   test "channel_leave message should remove member" do
-    new_slack = State.update(
-      %{type: "message", subtype: "channel_leave", user: "U123", channel: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "message", subtype: "channel_leave", user: "U123", channel: "123"},
+        slack()
+      )
 
     assert new_slack.channels["123"].members == []
   end
 
   test "presence_change message should update user" do
-    new_slack = State.update(
-      %{presence: "testing", type: "presence_change", user: "123"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{presence: "testing", type: "presence_change", user: "123"},
+        slack()
+      )
 
     assert new_slack.users["123"].presence == "testing"
   end
 
   test "bulk presence_change message should update users" do
-    new_slack = State.update(
-      %{presence: "testing", type: "presence_change", users: ["123", "U2"]},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{presence: "testing", type: "presence_change", users: ["123", "U2"]},
+        slack()
+      )
 
     assert new_slack.users["123"].presence == "testing"
     assert new_slack.users["U2"].presence == "testing"
   end
 
   test "group_joined event should add group" do
-    new_slack = State.update(
-      %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "group_joined", channel: %{id: "G123", members: ["U123", "U456"]}},
+        slack()
+      )
 
     assert new_slack.groups["G123"]
     assert new_slack.groups["G123"].members == ["U123", "U456"]
   end
 
   test "group_join message should add user to member list" do
-    new_slack = State.update(
-      %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "message", subtype: "group_join", channel: "G000", user: "U000"},
+        slack()
+      )
 
     assert Enum.member?(new_slack.groups["G000"][:members], "U000")
   end
 
   test "group_leave message should remove user from member list" do
-    new_slack = State.update(
-      %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "message", subtype: "group_leave", channel: "G000", user: "U111"},
+        slack()
+      )
 
     refute Enum.member?(new_slack.groups["G000"].members, "U111")
   end
 
   test "group_left message should remove group altogether" do
-    new_slack = State.update(
-      %{type: "group_left", channel: "G000"},
-      slack()
-    )
+    new_slack =
+      State.update(
+        %{type: "group_left", channel: "G000"},
+        slack()
+      )
 
     refute new_slack.groups["G000"]
   end
 
   test "im_created message should add direct message channel to list" do
     channel = %{name: "channel", id: "C456"}
-    new_slack = State.update(
-      %{type: "im_created", channel: channel},
-      slack()
-    )
+
+    new_slack =
+      State.update(
+        %{type: "im_created", channel: channel},
+        slack()
+      )
 
     assert new_slack.ims == %{"C456" => channel}
   end
 
   test "user_change merges an existing user" do
     user = %{id: "123", presence: "away", nickname: "Baz"}
-    new_slack = State.update(
-      %{type: "user_change", user: user},
-      slack()
-    )
+
+    new_slack =
+      State.update(
+        %{type: "user_change", user: user},
+        slack()
+      )
+
     assert new_slack.users["123"] == %{
-      id: "123",
-      name: "Bar",
-      presence: "away",
-      nickname: "Baz"
-    }
+             id: "123",
+             name: "Bar",
+             presence: "away",
+             nickname: "Baz"
+           }
   end
+
   test "user_change adds a new user" do
     user = %{id: "345", presence: "active", name: "Bar"}
-    new_slack = State.update(
-      %{type: "user_change", user: user},
-      slack()
-    )
+
+    new_slack =
+      State.update(
+        %{type: "user_change", user: user},
+        slack()
+      )
+
     assert new_slack.users["345"] == %{
-      id: "345",
-      name: "Bar",
-      presence: "active"
-    }
+             id: "345",
+             name: "Bar",
+             presence: "active"
+           }
   end
 
   defp slack do
@@ -228,7 +257,7 @@ defmodule Slack.StateTest do
         }
       },
       team: %{
-        name: "Foo",
+        name: "Foo"
       },
       users: %{
         "123" => %{
@@ -251,7 +280,7 @@ defmodule Slack.StateTest do
           name: "Bot"
         }
       },
-      ims: %{ }
+      ims: %{}
     }
   end
 end

--- a/test/support/fake_slack.ex
+++ b/test/support/fake_slack.ex
@@ -1,6 +1,7 @@
 defmodule Slack.FakeSlack do
   def start_link do
     Application.put_env(:slack, :url, "http://localhost:51345")
+
     Plug.Adapters.Cowboy.http(
       Slack.FakeSlack.Router,
       [],
@@ -14,12 +15,14 @@ defmodule Slack.FakeSlack do
   end
 
   defp dispatch do
-    [{
-      :_,
-      [
-        {"/ws", Slack.FakeSlack.Websocket, []},
-        {:_, Plug.Adapters.Cowboy.Handler, {Slack.FakeSlack.Router, []}}
-      ]
-    }]
+    [
+      {
+        :_,
+        [
+          {"/ws", Slack.FakeSlack.Websocket, []},
+          {:_, Plug.Adapters.Cowboy.Handler, {Slack.FakeSlack.Router, []}}
+        ]
+      }
+    ]
   end
 end

--- a/test/support/fake_slack/router.ex
+++ b/test/support/fake_slack/router.ex
@@ -2,14 +2,14 @@ defmodule Slack.FakeSlack.Router do
   use Plug.Router
   import Plug.Conn
 
-  plug :match
-  plug :dispatch
+  plug(:match)
+  plug(:dispatch)
 
   get "/api/rtm.start" do
     conn = fetch_query_params(conn)
 
     pid = Application.get_env(:slack, :test_pid)
-    send pid, {:token, conn.query_params["token"]}
+    send(pid, {:token, conn.query_params["token"]})
 
     response = ~S(
       {

--- a/test/support/fake_slack/websocket.ex
+++ b/test/support/fake_slack/websocket.ex
@@ -11,7 +11,7 @@ defmodule Slack.FakeSlack.Websocket do
     state = %{}
 
     pid = Application.get_env(:slack, :test_pid)
-    send pid, {:websocket_connected, self()}
+    send(pid, {:websocket_connected, self()})
 
     {:ok, req, state, @activity_timeout}
   end
@@ -22,7 +22,7 @@ defmodule Slack.FakeSlack.Websocket do
 
   def websocket_handle({:text, message}, req, state) do
     pid = Application.get_env(:slack, :test_pid)
-    send pid, {:bot_message, Poison.decode!(message)}
+    send(pid, {:bot_message, Poison.decode!(message)})
 
     {:ok, req, state}
   end


### PR DESCRIPTION
Elixir has a built-in autoformatter that allow us to keep codebase in one
consistent style. This should significantly improve reading and changing of code.

**Notable changes**:
* Codebase was formatted by Elixir's autoformatted
* `.formatter.exs` with initial configuration was created