### PR TITLE
Add Users.lookup_by_email to Web API

### DIFF
--- a/lib/slack/web/docs/users.lookupByEmail.json
+++ b/lib/slack/web/docs/users.lookupByEmail.json
@@ -1,0 +1,15 @@
+{
+	"desc": "Retrieve a single user by looking them up by their registered email address. Requires `users:read.email`.",
+
+	"args": {
+		"email": {
+			"type"		: "string",
+			"required"	: true,
+			"desc"		: "User's email address"
+		}
+	},
+
+	"errors": {
+		"user_not_found"	: "Value passed for `user` was invalid."
+	}
+}

--- a/lib/slack/web/docs/users.lookupByEmail.json
+++ b/lib/slack/web/docs/users.lookupByEmail.json
@@ -10,6 +10,7 @@
 	},
 
 	"errors": {
-		"user_not_found"	: "Value passed for `user` was invalid."
+		"user_not_found"	: "Value passed for `user` was invalid.",
+		"missing_scope"		: "The token used is not granted the specific scope permissions required to complete this request. Need: `users:read.email`."
 	}
 }


### PR DESCRIPTION
- This adds the new (?) method on the slack api for looking up users by their email