### PR TITLE
Issue #139: Username Lookup Fails for User IDs that Start with W.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /doc
 erl_crash.dump
 *.ez
+.idea
+*.iml

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -53,7 +53,11 @@ defmodule Slack.Lookups do
   end
 
   def lookup_user_name(user_id = "U" <> _id, slack) do
-    "@" <> slack.users[user_id].name
+    find_user_name(user_id, slack)
+  end
+
+  def lookup_user_name(user_id = "W" <> _id, slack) do
+    find_user_name(user_id, slack)
   end
 
   def lookup_user_name(bot_id = "B" <> _id, slack) do
@@ -76,5 +80,9 @@ defmodule Slack.Lookups do
 
   defp find_channel_by_name(nested_map, name) do
     Enum.find_value(nested_map, fn {_id, map} -> if map.name == name, do: map, else: nil end)
+  end
+
+  defp find_user_name(user_id, slack) do
+    "@" <> slack.users[user_id].name
   end
 end

--- a/test/slack/lookups_test.exs
+++ b/test/slack/lookups_test.exs
@@ -46,9 +46,14 @@ defmodule Slack.LookupsTest do
     assert Lookups.lookup_channel_id("#unknown", slack) == nil
   end
 
-  test "turns a user identifier into @user" do
+  test "turns a user identifier into @user for user ids that start with U" do
     slack = %{users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}}}
     assert Lookups.lookup_user_name("U123", slack) == "@user"
+  end
+
+  test "turns a user identifier into @user for user ids that start with W" do
+    slack = %{users: %{"W123" => %{name: "user", id: "W123", profile: %{display_name: "user"}}}}
+    assert Lookups.lookup_user_name("W123", slack) == "@user"
   end
 
   test "turns a direct message identifier into @user" do


### PR DESCRIPTION
In This PR
============
- [x] Minor update to the `.gitignore` to exclude Intellij project files.  (I can remove this if it is an annoyance.)
- [x] Added another version of `Slack.Lookups.lookup_user_name/2` which handles user ids that start with 'W', per the [documentation](https://api.slack.com/changelog/2016-08-11-user-id-format-changes).  This change addresses https://github.com/BlakeWilliams/Elixir-Slack/issues/139