### PR TITLE
Issue# 169: Deprecate Username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /doc
 erl_crash.dump
 *.ez
+
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ and body passed as arguments.
 In the case where you only need to control the options passed to HTTPoison/hackney, the default client accepts
 a keyword list as an additional configuration parameter. Note that this is ignored if configuring a custom client.
 
-See [HTTPoison docs](https://hexdocs.pm/httpoison/HTTPoison.html#request/5) for a list of avilable options.
+See [HTTPoison docs](https://hexdocs.pm/httpoison/HTTPoison.html#request/5) for a list of available options.
 
 ```elixir
 config :slack, :web_http_client_opts, [timeout: 10_000, recv_timeout: 10_000]

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -62,11 +62,11 @@ defmodule Slack.Lookups do
   end
 
   def lookup_user_name(user_id = "U" <> _id, slack) do
-    find_user_by_name(user_id, slack)
+    find_username_by_id(user_id, slack)
   end
 
   def lookup_user_name(user_id = "W" <> _id, slack) do
-    find_user_by_name(user_id, slack)
+    find_username_by_id(user_id, slack)
   end
 
   def lookup_user_name(bot_id = "B" <> _id, slack) do
@@ -91,7 +91,7 @@ defmodule Slack.Lookups do
     Enum.find_value(nested_map, fn {_id, map} -> if map.name == name, do: map, else: nil end)
   end
 
-  defp find_user_by_name(user_id, slack) do
+  defp find_username_by_id(user_id, slack) do
     "@" <> slack.users[user_id].name
   end
 end

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -1,5 +1,12 @@
 defmodule Slack.Lookups do
-  @moduledoc "Utility functions for looking up slack state informatin"
+  require Logger
+
+  @username_warning """
+  Referencing "@USER_NAME" is deprecated, and should not be used.
+  For more information see https://api.slack.com/changelog/2017-09-the-one-about-usernames
+  """
+
+  @moduledoc "Utility functions for looking up slack state information"
 
   @doc ~S"""
   Turns a string like `"@USER_NAME"` into the ID that Slack understands (`"U…"`).
@@ -8,6 +15,7 @@ defmodule Slack.Lookups do
   For more information see https://api.slack.com/changelog/2017-09-the-one-about-usernames
   """
   def lookup_user_id("@" <> user_name, slack) do
+    Logger.warn(@username_warning)
     slack.users
     |> Map.values()
     |> Enum.find(%{}, fn user ->
@@ -70,6 +78,7 @@ defmodule Slack.Lookups do
   end
 
   def lookup_user_name(bot_id = "B" <> _id, slack) do
+    Logger.warn(@username_warning)
     "@" <> slack.bots[bot_id].name
   end
 
@@ -92,6 +101,7 @@ defmodule Slack.Lookups do
   end
 
   defp find_username_by_id(user_id, slack) do
+    Logger.warn(@username_warning)
     "@" <> slack.users[user_id].name
   end
 end

--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -3,6 +3,9 @@ defmodule Slack.Lookups do
 
   @doc ~S"""
   Turns a string like `"@USER_NAME"` into the ID that Slack understands (`"U…"`).
+
+  NOTE: Referencing `"@USER_NAME"` is deprecated, and should not be used.
+  For more information see https://api.slack.com/changelog/2017-09-the-one-about-usernames
   """
   def lookup_user_id("@" <> user_name, slack) do
     slack.users
@@ -17,6 +20,9 @@ defmodule Slack.Lookups do
   Turns a string like `"@USER_NAME"` or a user ID (`"U…"`) into the ID for the
   direct message channel of that user (`"D…"`).  `nil` is returned if a direct
   message channel has not yet been opened.
+
+  NOTE: Referencing `"@USER_NAME"` is deprecated, and should not be used.
+  For more information see https://api.slack.com/changelog/2017-09-the-one-about-usernames
   """
   def lookup_direct_message_id(user = "@" <> _user_name, slack) do
     user
@@ -47,13 +53,20 @@ defmodule Slack.Lookups do
   @doc ~S"""
   Turns a Slack user ID (`"U…"`), direct message ID (`"D…"`), or bot ID (`"B…"`)
   into a string in the format "@USER_NAME".
+
+  NOTE: Referencing `"@USER_NAME"` is deprecated, and should not be used.
+  For more information see https://api.slack.com/changelog/2017-09-the-one-about-usernames
   """
   def lookup_user_name(direct_message_id = "D" <> _id, slack) do
     lookup_user_name(slack.ims[direct_message_id].user, slack)
   end
 
   def lookup_user_name(user_id = "U" <> _id, slack) do
-    "@" <> slack.users[user_id].name
+    find_user_by_name(user_id, slack)
+  end
+
+  def lookup_user_name(user_id = "W" <> _id, slack) do
+    find_user_by_name(user_id, slack)
   end
 
   def lookup_user_name(bot_id = "B" <> _id, slack) do
@@ -76,5 +89,9 @@ defmodule Slack.Lookups do
 
   defp find_channel_by_name(nested_map, name) do
     Enum.find_value(nested_map, fn {_id, map} -> if map.name == name, do: map, else: nil end)
+  end
+
+  defp find_user_by_name(user_id, slack) do
+    "@" <> slack.users[user_id].name
   end
 end

--- a/test/slack/lookups_test.exs
+++ b/test/slack/lookups_test.exs
@@ -46,15 +46,29 @@ defmodule Slack.LookupsTest do
     assert Lookups.lookup_channel_id("#unknown", slack) == nil
   end
 
-  test "turns a user identifier into @user" do
+  test "turns a user identifier into @user (Uxxxx)" do
     slack = %{users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}}}
     assert Lookups.lookup_user_name("U123", slack) == "@user"
   end
 
-  test "turns a direct message identifier into @user" do
+  test "turns a user identifier into @user (Wxxxx)" do
+    slack = %{users: %{"W123" => %{name: "user", id: "W123", profile: %{display_name: "user"}}}}
+    assert Lookups.lookup_user_name("W123", slack) == "@user"
+  end
+
+  test "turns a direct message identifier into @user (Uxxxx)" do
     slack = %{
       users: %{"U123" => %{name: "user", id: "U123", profile: %{display_name: "user"}}},
       ims: %{"D789" => %{user: "U123", id: "D789"}}
+    }
+
+    assert Lookups.lookup_user_name("D789", slack) == "@user"
+  end
+
+  test "turns a direct message identifier into @user (Wxxxx)" do
+    slack = %{
+      users: %{"W123" => %{name: "user", id: "W123", profile: %{display_name: "user"}}},
+      ims: %{"D789" => %{user: "W123", id: "D789"}}
     }
 
     assert Lookups.lookup_user_name("D789", slack) == "@user"

--- a/test/slack/sends_test.exs
+++ b/test/slack/sends_test.exs
@@ -57,6 +57,18 @@ defmodule Slack.SendsTest do
     assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
   end
 
+  test "send_message understands user ids (Wxxx)" do
+    slack = %{
+      process: nil,
+      client: FakeWebsocketClient,
+      users: %{"W123" => %{name: "user", id: "W123"}},
+      ims: %{"D789" => %{user: "W123", id: "D789"}}
+    }
+
+    result = Sends.send_message("hello", "W123", slack)
+    assert result == {nil, ~s/{"type":"message","text":"hello","channel":"D789"}/}
+  end
+
   test "indicate_typing sends typing notification to client" do
     result = Sends.indicate_typing("channel", %{process: nil, client: FakeWebsocketClient})
     assert result == {nil, ~s/{"type":"typing","channel":"channel"}/}


### PR DESCRIPTION
In This PR
=========
- [x] Adding support for `user_id`s that start with 'W'.
- [x] `Slack.Sends.send_message/3` for a `user_id` no longer attempts to look up a username. It now looks up the `direct_message_id`.  The behavior for the `@USER_NAME` variant is the same; it still attempts to look up the `user_id` first.  
- [x] Minor update to the `.gitignore` to exclude intellij project files (I can remove this if it is an annoyance.).
- [x] Added `@USER_NAME` deprecation messages to the function documentation.