### PR TITLE
Add docs for bot accessible Conversation APIs

### DIFF
--- a/lib/slack/web/docs/conversations.close.json
+++ b/lib/slack/web/docs/conversations.close.json
@@ -1,0 +1,15 @@
+{
+  "desc": "Closes direct messages, multi-person or 1:1 or otherwise.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation to close."
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid"
+  }
+}

--- a/lib/slack/web/docs/conversations.history.json
+++ b/lib/slack/web/docs/conversations.history.json
@@ -1,0 +1,44 @@
+{
+  "desc": "Returns a portion of message events from the specified conversation.\n\nBot user tokens may use this method for direct message and multi-party direct message conversations but lack sufficient permissions to use this method on public and private channels.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation ID to fetch history for."
+    },
+    "cursor": {
+      "example" : "dXNlcjpVMDYxTkZUVDI=",
+      "required": false,
+      "desc"    : "Paginate through collections of data by setting the cursor parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first \"page\" of the collection. See pagination for more detail."
+    },
+    "inclusive": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+      "default" : 0
+    },
+    "latest": {
+      "example" : "1234567890.123456",
+      "required": false,
+      "desc"    : "End of time range of messages to include in results.",
+      "default" : "now"
+    },
+    "limit": {
+      "example" : 20,
+      "required": false,
+      "desc"    : "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+      "default" : 100
+    },
+    "oldest": {
+      "example" : "1234567890.123456",
+      "required": false,
+      "desc"    : "Start of time range of messages to include in results.",
+      "default" : 0
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid"
+  }
+}

--- a/lib/slack/web/docs/conversations.info.json
+++ b/lib/slack/web/docs/conversations.info.json
@@ -1,0 +1,27 @@
+{
+  "desc": "Returns information about a workspace conversation.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation ID to learn more about."
+    },
+    "include_locale": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Set this to `true` to receive the locale for this conversation. Defaults to `false`",
+      "default" : "false"
+    },
+    "include_num_members": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Set to `true` to include the member count for the specified conversation. Defaults to `false`",
+      "default" : "false"
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid"
+  }
+}

--- a/lib/slack/web/docs/conversations.list.json
+++ b/lib/slack/web/docs/conversations.list.json
@@ -1,0 +1,36 @@
+{
+  "desc": "Returns a list of all channel-like conversations in a workspace.",
+
+  "args": {
+    "cursor": {
+      "example" : "dXNlcjpVMDYxTkZUVDI=",
+      "required": false,
+      "desc"    : "Paginate through collections of data by setting the cursor parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first \"page\" of the collection. See pagination for more detail."
+    },
+    "exclude_archived": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Set this to `true` to exclude archived channels from the list",
+      "default" : "false"
+    },
+    "limit": {
+      "example" : 20,
+      "required": false,
+      "desc"    : "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer no larger than 1000.",
+      "default" : 100
+    },
+    "types": {
+      "example" : "public_channel,private_channel",
+      "required": false,
+      "desc"    : "Mix and match channel types by providing a comma-separated list of any combination of `public_channel`, `private_channel`, `mpim`, `im`",
+      "default" : "public_channel"
+    }
+  },
+
+  "errors": {
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+    "invalid_limit": "Value passed for `limit` was invalid.",
+    "invalid_cursor": "Value passed for `cursor` was invalid.",
+    "invalid_types": "Value passed for type could not be used based on the method's capabilities or the permission scopes granted to the used token."
+  }
+}

--- a/lib/slack/web/docs/conversations.members.json
+++ b/lib/slack/web/docs/conversations.members.json
@@ -1,0 +1,36 @@
+{
+  "desc": "Returns a paginated list of members party to a conversation.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "ID of the conversation to retrieve members for"
+    },
+    "cursor": {
+      "example" : "dXNlcjpVMDYxTkZUVDI=",
+      "required": false,
+      "desc"    : "Paginate through collections of data by setting the cursor parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first \"page\" of the collection. See pagination for more detail."
+    },
+    "exclude_archived": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Set this to `true` to exclude archived channels from the list",
+      "default" : "false"
+    },
+    "limit": {
+      "example" : 20,
+      "required": false,
+      "desc"    : "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached.",
+      "default" : 100
+    }
+  },
+
+  "errors": {
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+    "channel_not_found": "Value passed for `channel` was invalid.",
+    "invalid_limit": "Value passed for `limit` was invalid.",
+    "invalid_cursor": "Value passed for `cursor` was invalid.",
+    "fetch_members_failed": "Failed to fetch members for the conversation."
+  }
+}

--- a/lib/slack/web/docs/conversations.open.json
+++ b/lib/slack/web/docs/conversations.open.json
@@ -1,0 +1,32 @@
+{
+  "desc": "Opens a multi-person direct message or just a 1:1 direct message.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": false,
+      "desc"    : "Resume a conversation by supplying an `im` or `mpim`'s ID. Or provide the `users` field instead."
+    },
+    "return_im": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Boolean, indicates you want the full IM channel definition in the response."
+    },
+    "users": {
+      "example" : "W1234567890,U2345678901,U3456789012",
+      "required": false,
+      "desc"    : "Comma separated lists of users. If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a `channel` when not supplying `users`."
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid",
+    "user_not_found": "Value(s) passed for `users` was invalid",
+    "user_not_visible": "The calling user is restricted from seeing the requested user.",
+    "user_disabled": "A specified `user` has been disabled",
+    "users_list_not_supplied": "Missing `users` in request",
+    "not_enough_users": "Needs at least 2 users to open",
+    "too_many_users": "Needs at most 8 users to open",
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method."
+  }
+}

--- a/lib/slack/web/docs/conversations.replies.json
+++ b/lib/slack/web/docs/conversations.replies.json
@@ -1,0 +1,53 @@
+{
+  "desc": "Returns an entire thread (a message plus all the messages in reply to it), while `conversations.history` method returns only parent messages.\n\nBot user tokens may use this method for direct message and multi-party direct message conversations but lack sufficient permissions to use this method on public and private channels.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation ID to fetch thread from."
+    },
+    "ts": {
+      "example" : "1234567890.123456",
+      "required": true,
+      "desc"    : "Unique identifier of a thread's parent message."
+    },
+    "inclusive": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+      "default" : 0
+    },
+    "cursor": {
+      "example" : "dXNlcjpVMDYxTkZUVDI=",
+      "required": false,
+      "desc"    : "Paginate through collections of data by setting the cursor parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first \"page\" of the collection. See pagination for more detail."
+    },
+    "latest": {
+      "example" : "1234567890.123456",
+      "required": false,
+      "desc"    : "End of time range of messages to include in results.",
+      "default" : "now"
+    },
+    "limit": {
+      "example" : 20,
+      "required": false,
+      "desc"    : "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+      "default" : 100
+    },
+    "oldest": {
+      "example" : "1234567890.123456",
+      "required": false,
+      "desc"    : "Start of time range of messages to include in results.",
+      "default" : 0
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value for `channel` was invalid",
+    "thread_not_found": "Value for `ts` was missing or invalid",
+    "invalid_cursor": "Value passed for `cursor` was invalid.",
+    "invalid_ts_latest": "Value passed for `latest` was invalid.",
+    "invalid_ts_oldest": "Value passed for `oldest` was invalid."
+  }
+}

--- a/lib/slack/web/docs/conversations.setPurpose.json
+++ b/lib/slack/web/docs/conversations.setPurpose.json
@@ -1,0 +1,25 @@
+{
+  "desc": "Change the purpose of a conversation. The calling user must be a member of the conversation. Not all conversation types may have a purpose set.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation to set the purpose of."
+    },
+    "purpose": {
+      "example" : "My More Special Purpose",
+      "required": true,
+      "desc"    : "A new, specialer purpose"
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid",
+    "not_in_channel": "Authenticated user is not in the channel.",
+    "is_archived": "Channel has been archived",
+    "too_long": "Purpose was longer than 250 characters.",
+    "user_is_restricted": "This method cannot be called by a restricted user or single channel guest.",
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method."
+  }
+}

--- a/lib/slack/web/docs/conversations.setTopic.json
+++ b/lib/slack/web/docs/conversations.setTopic.json
@@ -1,0 +1,25 @@
+{
+  "desc": "Change the topic of a conversation. The calling user must be a member of the conversation. Not all conversation types may have a purpose set.",
+
+  "args": {
+    "channel": {
+      "example" : "G1234567890",
+      "required": true,
+      "desc"    : "Conversation to set the purpose of."
+    },
+    "topic": {
+      "example" : "Apply topically for best effects",
+      "required": true,
+      "desc"    : "The new topic string. Does not support formatting or linkification."
+    }
+  },
+
+  "errors": {
+    "channel_not_found": "Value passed for `channel` was invalid",
+    "not_in_channel": "Authenticated user is not in the channel.",
+    "is_archived": "Channel has been archived",
+    "too_long": "Topic was longer than 250 characters.",
+    "user_is_restricted": "This method cannot be called by a restricted user or single channel guest.",
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method."
+  }
+}

--- a/lib/slack/web/docs/users.conversations.json
+++ b/lib/slack/web/docs/users.conversations.json
@@ -1,0 +1,38 @@
+{
+  "desc": "Returns a list of all channel-like conversations accessible to the user or app tied to the presented token, as part of Conversations API.",
+
+  "args": {
+    "cursor": {
+      "example" : "dXNlcjpVMDYxTkZUVDI=",
+      "required": false,
+      "desc"    : "Paginate through collections of data by setting the cursor parameter to a `next_cursor` attribute returned by a previous request's `response_metadata`. Default value fetches the first \"page\" of the collection. See pagination for more detail."
+    },
+    "exclude_archived": {
+      "example" : "true",
+      "required": false,
+      "desc"    : "Set this to `true` to exclude archived channels from the list",
+      "default" : "false"
+    },
+    "limit": {
+      "example" : 20,
+      "required": false,
+      "desc"    : "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer no larger than 1000.",
+      "default" : 100
+    },
+    "types": {
+      "example" : "public_channel,private_channel",
+      "required": false,
+      "desc"    : "Mix and match channel types by providing a comma-separated list of any combination of `public_channel`, `private_channel`, `mpim`, `im`",
+      "default" : "public_channel"
+    },
+    "user": {
+      "example" : "W0B2345D",
+      "required": false,
+      "desc"    : "Browse conversations by a specific user ID's membership. Non-public channels are restricted to those where the calling user shares membership."
+    }
+  },
+
+  "errors": {
+    "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method."
+  }
+}


### PR DESCRIPTION
These are bot accessible (except for `set_purpose` and `set_topic`, which only work with legacy bot tokens) Conversations API definitions.

`Slack.Web.Conversations.info` in particular is useful for determining whether the arriving message was passed through direct message, group mention, private chat, or public chat, as RTM API doesn't differentiate on message types.

I've done some basic smoke tests and the endpoints seem to be returning the information I expect to see. There are some limitations on what conversations bots can operate, even if the API is exposed to bots. I've extended two descriptions beyond required minimum to indicate this.