### PR TITLE
Support web HTTP options with all HTTPoison requests

### DIFF
--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -12,9 +12,13 @@ defmodule Slack.Rtm do
   @moduledoc false
 
   def start(token) do
-    slack_url(token)
-    |> HTTPoison.get()
-    |> handle_response()
+    with url <- slack_url(token),
+         headers <- [],
+         options <- Application.get_env(:slack, :web_http_client_opts, []) do
+      url
+      |> HTTPoison.get(headers, options)
+      |> handle_response()
+    end
   end
 
   defp handle_response({:ok, %HTTPoison.Response{body: body}}) do

--- a/lib/slack/sends.ex
+++ b/lib/slack/sends.ex
@@ -102,13 +102,12 @@ defmodule Slack.Sends do
   end
 
   defp open_im_channel(token, user_id, on_success, on_error) do
-    url = Application.get_env(:slack, :url, "https://slack.com")
-
     im_open =
-      HTTPoison.post(
-        url <> "/api/im.open",
-        {:form, [token: token, user: user_id]}
-      )
+      with url <- Application.get_env(:slack, :url, "https://slack.com") <> "/api/im.open",
+           headers <- {:form, [token: token, user: user_id]},
+           options <- Application.get_env(:slack, :web_http_client_opts, []) do
+        HTTPoison.post(url, headers, options)
+      end
 
     case im_open do
       {:ok, response} ->


### PR DESCRIPTION
This was previously only supported in `Slack.Web.DefaultClient`.  This change allows SSL and other options to be used.