### PR TITLE
Fix application list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 19.2
+    - otp_release: 19.3
       elixir: 1.4.0
       env: MIX_ENV=test
     - otp_release: 20.3
       elixir: 1.6.6
       env: MIX_ENV=test
-    - otp_release: 22
+    - otp_release: 22.0
       elixir: 1.9.1
       env: MIX_ENV=test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 18.1
-      elixir: 1.3.0
-      env: MIX_ENV=test
     - otp_release: 19.2
       elixir: 1.4.0
+      env: MIX_ENV=test
+    - otp_release: 20.3
+      elixir: 1.6.6
+      env: MIX_ENV=test
+    - otp_release: 22
+      elixir: 1.9.1
       env: MIX_ENV=test
 after_success:
   - mix coveralls.travis

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Slack.Mixfile do
     [
       app: :slack,
       version: "0.19.0",
-      elixir: "~> 1.2",
+      elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Slack",
       deps: deps(),
@@ -20,7 +20,9 @@ defmodule Slack.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [applications: [:logger, :httpoison, :hackney, :crypto, :websocket_client]]
+    [
+      extra_applications: [:logger]
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
Previously all applications were directly specified, however, `:poison` was missed. This means that if you create a release, the `:posion` would not exist. Instead switch from `:applications` to `:extra_applications` so that Elixir can build the list for us.

Requires Elixir 1.4 which was released 2.5 years ago:
https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/

Fixes #195