### PR TITLE
added conversations methods to web api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ erl_crash.dump
 
 .idea
 *.iml
+.elixir_ls
+
+.DS_Store

--- a/lib/slack/web/docs/bak
+++ b/lib/slack/web/docs/bak
@@ -1,0 +1,50 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        },
+        "cursor": {
+            "desc": "Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first 'page' of the collection. See pagination for more detail.",
+            "required": false
+        },
+        "exclude_archived": {
+            "desc": "Set to true to exclude archived channels from the list.",
+            "required": false
+        },
+        "limit": {
+            "desc": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer no larger than 1000.",
+            "required": false
+        },
+        "types": {
+            "desc": "Mix and match channel types by providing a comma-separated list of any combination of public_channel, private_channel, mpim, im",
+            "required": false
+        }
+    },
+    "desc": "This Conversations API method returns a list of all channel-like conversations in a workspace. The 'channels' returned depend on what the calling token has access to and the directives placed in the types parameter.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_cursor": "Value passed for cursor was not valid or is no longer valid.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "invalid_ts_latest": "Value passed for latest was invalid",
+        "invalid_ts_oldest": "Value passed for oldest was invalid",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "pagination_not_available": "Pagination does not currently function on Enterprise Grid workspaces.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.archive.json
+++ b/lib/slack/web/docs/conversations.archive.json
@@ -1,0 +1,36 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        }
+    },
+    "desc": "This method archives a conversation. Not all types of conversations can be archived.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "already_archived": "Channel has already been archived.",
+        "cant_archive_general": "You cannot archive the general channel",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "restricted_action": "A team preference prevents the authenticated user from archiving.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.close.json
+++ b/lib/slack/web/docs/conversations.close.json
@@ -1,0 +1,32 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        }
+    },
+    "desc": "This Conversations API method closes direct messages, multi-person or 1:1 or otherwise.mi",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_does_not_own_channel": "Calling user does not own this DM channel."
+    }
+}

--- a/lib/slack/web/docs/conversations.create.json
+++ b/lib/slack/web/docs/conversations.create.json
@@ -1,0 +1,55 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        },
+        "is_private": {
+            "desc": "Create a private channel instead of a public one",
+            "required": false
+        },
+        "name": {
+            "desc": "Authentication token bearing required scopes.",
+            "required": true
+        },
+        "user_ids": {
+            "desc": "Required for workspace apps. A list of between 1 and 30 human users that will be added to the newly-created conversation. This argument has no effect when used by classic Slack apps.",
+            "required": false
+        }
+    },
+    "desc": "Create a public or private channel using this Conversations API method.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_name": "Value passed for name was invalid.",
+        "invalid_name_maxlength": "Value passed for name exceeded max length.",
+        "invalid_name_punctuation": "Value passed for name contained only punctuation.",
+        "invalid_name_required": "Value passed for name was empty.",
+        "invalid_name_specials": "Value passed for name contained unallowed special characters or upper case characters.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "invalid_users": "Value passed for user_ids was empty or invalid.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "name_taken": "A channel cannot be created with the given name.",
+        "no_channel": "Value passed for name was empty.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "restricted_action": "A team preference prevents the authenticated user from creating channels.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "too_many_convos_for_app_on_team": "This app has exceeded its per-workspace limit of public and private channels.",
+        "too_many_convos_for_team": "The workspace has exceeded its limit of public and private channels.",
+        "user_is_ultra_restricted": "This method cannot be called by a single channel guest.",
+        "user_not_found": "One or more users in user_ids was not found."
+    }
+}

--- a/lib/slack/web/docs/conversations.history.json
+++ b/lib/slack/web/docs/conversations.history.json
@@ -1,0 +1,54 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        },
+        "cursor": {
+            "desc": "Conversation ID to fetch history for.",
+            "required": false
+        },
+        "inclusive": {
+            "desc": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+            "required": false
+        },
+        "latest": {
+            "desc": "End of time range of messages to include in results.",
+            "required": false
+        },
+        "limit": {
+            "desc": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+            "required": false
+        },
+        "oldest": {
+            "desc": "Start of time range of messages to include in results.",
+            "required": false
+        }
+    },
+    "desc": "This method returns a portion of message events from the specified conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_cursor": "Value passed for cursor was not valid or is no longer valid.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "invalid_ts_latest": "Value passed for latest was invalid",
+        "invalid_ts_oldest": "Value passed for oldest was invalid",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "pagination_not_available": "Pagination does not currently function on Enterprise Grid workspaces.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.info.json
+++ b/lib/slack/web/docs/conversations.info.json
@@ -1,0 +1,38 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        },
+        "include_locale": {
+            "desc": "Conversation ID to learn more about.",
+            "required": false
+        },
+        "include_num_members": {
+            "desc": "Set to true to include the member count for the specified conversation. Defaults to false",
+            "required": false
+        }
+    },
+    "desc": "This Conversations API method returns information about a workspace conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.invite.json
+++ b/lib/slack/web/docs/conversations.invite.json
@@ -1,0 +1,45 @@
+{
+    "args": {
+        "channel": {
+            "desc": "The ID of the public or private channel to invite user(s) to.",
+            "required": true,
+            "type": "channel"
+        },
+        "users": {
+            "desc": "A comma separated list of user IDs. Up to 30 users may be listed.",
+            "required": true
+        }
+    },
+    "desc": "This Conversations API method invites 1-30 users to a public or private channel. The calling user must be a member of the channel.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "already_in_channel": "Invited user is already in the channel.",
+        "cant_invite": "User cannot be invited to this channel.",
+        "cant_invite_self": "Authenticated user cannot invite themselves to a channel.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_archived": "Channel has been archived.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "no_user": "No value was passed for users.",
+        "not_authed": "No authentication token provided.",
+        "not_in_channel": "Authenticated user is not in the channel.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "ura_max_channels": "URA is already in the maximum number of channels.",
+        "user_is_ultra_restricted": "This method cannot be called by a single channel guest.",
+        "user_not_found": "Value passed for users was invalid."
+    }
+}

--- a/lib/slack/web/docs/conversations.join.json
+++ b/lib/slack/web/docs/conversations.join.json
@@ -1,0 +1,34 @@
+{
+    "args": {
+        "channel": {
+            "desc": "The ID of the public or private channel to invite user(s) to.",
+            "required": true,
+            "type": "channel"
+        }
+    },
+    "desc": "This Conversations API method joins a user to an existing conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_archived": "Channel has been archived.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.kick.json
+++ b/lib/slack/web/docs/conversations.kick.json
@@ -1,0 +1,42 @@
+{
+    "args": {
+        "channel": {
+            "desc": "The ID of the public or private channel to invite user(s) to.",
+            "required": true,
+            "type": "channel"
+        },
+        "user": {
+            "desc": "The ID of the public or private channel to invite user(s) to.",
+            "required": true
+        }
+    },
+    "desc": "This Conversations API method allows a user to remove another member from a channel.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "cant_kick_from_general": "User cannot be removed from #general.",
+        "cant_kick_self": "Authenticated user can't kick themselves from a channel.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "not_in_channel": "User was not in the channel.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "restricted_action": "A team preference prevents the authenticated user from kicking.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest.",
+        "user_not_found": "Value passed for user was invalid."
+    }
+}

--- a/lib/slack/web/docs/conversations.leave.json
+++ b/lib/slack/web/docs/conversations.leave.json
@@ -1,0 +1,35 @@
+{
+    "args": {
+        "channel": {
+            "desc": "The ID of the public or private channel to invite user(s) to.",
+            "required": true,
+            "type": "channel"
+        }
+    },
+    "desc": "This Conversations API method makes like a tree and leaves a conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "cant_leave_general": "Authenticated user cannot leave the general channel",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_archived": "Channel has been archived.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_ultra_restricted": "This method cannot be called by a single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.list.json
+++ b/lib/slack/web/docs/conversations.list.json
@@ -1,0 +1,49 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to archive",
+            "required": true,
+            "type": "channel"
+        },
+        "cursor": {
+            "desc": "Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first 'page' of the collection. See pagination for more detail.",
+            "required": false
+        },
+        "exclude_archived": {
+            "desc": "Set to true to exclude archived channels from the list.",
+            "required": false
+        },
+        "limit": {
+            "desc": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn't been reached. Must be an integer no larger than 1000.",
+            "required": false
+        },
+        "types": {
+            "desc": "Mix and match channel types by providing a comma-separated list of any combination of public_channel, private_channel, mpim, im",
+            "required": false
+        }
+    },
+    "desc": "This Conversations API method returns a list of all channel-like conversations in a workspace. The 'channels' returned depend on what the calling token has access to and the directives placed in the types parameter.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_cursor": "Value passed for cursor was not valid or is no longer valid.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_limit": "Value passed for limit is not understood.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "invalid_types": "Value passed for type could not be used based on the method's capabilities or the permission scopes granted to the used token.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.members.json
+++ b/lib/slack/web/docs/conversations.members.json
@@ -1,0 +1,42 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of the conversation to retrieve members for.",
+            "required": true,
+            "type": "channel"
+        },
+        "cursor": {
+            "desc": "Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first page of the collection. See pagination for more detail.",
+            "required": false
+        },
+        "limit": {
+            "desc": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+            "required": false
+        }
+    },
+    "desc": "This Conversations API method returns a paginated list of members party to a conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "fetch_members_failed": "Failed to fetch members for the conversation.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_cursor": "Value passed for cursor was invalid.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_limit": "Value passed for limit was invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.open.json
+++ b/lib/slack/web/docs/conversations.open.json
@@ -1,0 +1,45 @@
+{
+    "args": {
+        "channel": {
+            "desc": "Resume a conversation by supplying an im or mpim's ID. Or provide the users field instead.",
+            "required": false,
+            "type": "channel"
+        },
+        "return_im": {
+            "desc": "Boolean, indicates you want the full IM channel definition in the response.",
+            "required": false
+        },
+        "users": {
+            "desc": "Comma separated lists of users. If only one user is included, this creates a 1:1 DM. The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a channel when not supplying users.",
+            "required": false
+        }
+    },
+    "desc": "This Conversations API method opens a multi-person direct message or just a 1:1 direct message.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "not_enough_users": "Needs at least 2 users to open",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "too_many_users": "Needs at most 8 users to open",
+        "user_disabled": "A specified user has been disabled.",
+        "user_not_found": "Value(s) passed for users was invalid.",
+        "user_not_visible": "The calling user is restricted from seeing the requested user.",
+        "users_list_not_supplied": "Missing users in request"
+    }
+}

--- a/lib/slack/web/docs/conversations.rename.json
+++ b/lib/slack/web/docs/conversations.rename.json
@@ -1,0 +1,45 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to rename.",
+            "required": true,
+            "type": "channel"
+        },
+        "name": {
+            "desc": "New name for conversation.",
+            "required": true
+        }
+    },
+    "desc": "This method renames a conversation. Some types of conversations cannot be renamed.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_name": "Value passed for name was invalid.",
+        "invalid_name_maxlength": "Value passed for name exceeded max length.",
+        "invalid_name_punctuation": "Value passed for name contained only punctuation.",
+        "invalid_name_required": "Value passed for name was empty.",
+        "invalid_name_specials": "Value passed for name contained unallowed special characters or upper case characters.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "name_taken": "New channel name is taken",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "not_authorized": "Caller cannot rename this channel",
+        "not_in_channel": "Caller is not a member of the channel.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.replies.json
+++ b/lib/slack/web/docs/conversations.replies.json
@@ -1,0 +1,58 @@
+{
+    "args": {
+        "channel": {
+            "desc": "Conversation ID to fetch thread from.",
+            "required": true,
+            "type": "channel"
+        },
+        "cursor": {
+            "desc": "Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata. Default value fetches the first 'page' of the collection. See pagination for more detail.",
+            "required": false
+        },
+        "inclusive": {
+            "desc": "Include messages with latest or oldest timestamp in results only when either timestamp is specified.",
+            "required": false
+        },
+        "latest": {
+            "desc": "End of time range of messages to include in results.",
+            "required": false
+        },
+        "limit": {
+            "desc": "The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.",
+            "required": false
+        },
+        "oldest": {
+            "desc": "Start of time range of messages to include in results.",
+            "required": false
+        },
+        "ts": {
+            "desc": "Unique identifier of a thread's parent message.",
+            "required": true
+        }
+    },
+    "desc": "This Conversations API method returns an entire thread (a message plus all the messages in reply to it), while conversations.history method returns only parent messages.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value for channel was missing or invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_cursor": "Value passed for cursor was not valid or is no longer valid.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "invalid_ts_latest": "Value passed for latest was invalid",
+        "invalid_ts_oldest": "Value passed for oldest was invalid",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "thread_not_found": "Value for ts was missing or invalid.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed."
+    }
+}

--- a/lib/slack/web/docs/conversations.setPurpose.json
+++ b/lib/slack/web/docs/conversations.setPurpose.json
@@ -1,0 +1,39 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to rename.",
+            "required": true,
+            "type": "channel"
+        },
+        "purpose": {
+            "desc": "A new, specialer purpose",
+            "required": true
+        }
+    },
+    "desc": "This method is used to change the purpose of a conversation. The calling user must be a member of the conversation. Not all conversation types may have a purpose set.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_archived": "Channel has been archived.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "not_in_channel": "Authenticated user is not in the channel.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "too_long": "Purpose was longer than 250 characters.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.setTopic.json
+++ b/lib/slack/web/docs/conversations.setTopic.json
@@ -1,0 +1,39 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to rename.",
+            "required": true,
+            "type": "channel"
+        },
+        "topic": {
+            "desc": "The new topic string. Does not support formatting or linkification.",
+            "required": true
+        }
+    },
+    "desc": "This method is used to change the topic of a conversation. The calling user must be a member of the conversation. Not all conversation types support a new topic.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_archived": "Channel has been archived.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_authed": "No authentication token provided.",
+        "not_in_channel": "Authenticated user is not in the channel.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "too_long": "Topic was longer than 250 characters.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}

--- a/lib/slack/web/docs/conversations.unarchive.json
+++ b/lib/slack/web/docs/conversations.unarchive.json
@@ -1,0 +1,34 @@
+{
+    "args": {
+        "channel": {
+            "desc": "ID of conversation to unarchive",
+            "required": true,
+            "type": "channel"
+        }
+    },
+    "desc": "This method unarchives a conversation. The calling user is added to the conversation.",
+    "errors": {
+        "account_inactive": "Authentication token is for a deleted user or workspace.",
+        "channel_not_found": "Value passed for channel was invalid.",
+        "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+        "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_arguments": "The method was called with invalid arguments.",
+        "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "invalid_charset": "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data": "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type": "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "is_bot": "This method cannot be called by a bot user.",
+        "method_not_supported_for_channel_type": "This type of conversation cannot be used with this method.",
+        "missing_post_type": "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+        "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "not_archived": "Channel is not archived.",
+        "not_authed": "No authentication token provided.",
+        "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "request_timeout": "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "user_is_restricted": "This method cannot be called by a restricted user or single channel guest."
+    }
+}


### PR DESCRIPTION
I have added all the conversation API methods. I have done so by copy/pasting them from the website and using some emacs macros. I have not tested all of them, except the history one. I did make sure the mix test task succeeds.

Couple of remaining questions I have:

    Please tell me you did not have an automation script for this?
    Do you need to me to verify they all work somehow?

(This time without .DS_Store files :)