### PR TITLE
Fix some deprecated warnings

### DIFF
--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -74,7 +74,6 @@ defmodule Slack.Bot do
   # websocket_client API
 
   @doc false
-  @since "0.19.0"
   @deprecated """
   `rtm.start` is replaced with `rtm.connect` and will no longer receive bots, channels, groups, users, or IMs.
   In future versions these will no longer be provided on initialization.

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -59,7 +59,7 @@ defmodule Slack.State do
       ) do
     put_in(slack, [:channels, channel, :topic], %{
       creator: user,
-      last_set: System.system_time(:seconds),
+      last_set: System.system_time(:second),
       value: topic
     })
   end
@@ -70,7 +70,7 @@ defmodule Slack.State do
       ) do
     put_in(slack, [:groups, channel, :topic], %{
       creator: user,
-      last_set: System.system_time(:seconds),
+      last_set: System.system_time(:second),
       value: topic
     })
   end

--- a/test/slack/state_test.exs
+++ b/test/slack/state_test.exs
@@ -74,7 +74,7 @@ defmodule Slack.StateTest do
   end
 
   test "team_join adds user to users" do
-    user_length = Map.size(slack().users)
+    user_length = map_size(slack().users)
 
     new_slack =
       State.update(
@@ -82,7 +82,7 @@ defmodule Slack.StateTest do
         slack()
       )
 
-    assert Map.size(new_slack.users) == user_length + 1
+    assert map_size(new_slack.users) == user_length + 1
   end
 
   test "user_change updates user" do
@@ -97,7 +97,7 @@ defmodule Slack.StateTest do
   end
 
   test "bot_added adds bot to bots" do
-    bot_length = Map.size(slack().bots)
+    bot_length = map_size(slack().bots)
 
     new_slack =
       State.update(
@@ -105,7 +105,7 @@ defmodule Slack.StateTest do
         slack()
       )
 
-    assert Map.size(new_slack.bots) == bot_length + 1
+    assert map_size(new_slack.bots) == bot_length + 1
   end
 
   test "bot_changed updates bot in bots" do


### PR DESCRIPTION
### Context

Actually I wanted to work on this issue first https://github.com/BlakeWilliams/Elixir-Slack/issues/127. 
But I faced some annoying warnings so I thought why not just fix them first.

Please have a look when you have time, thank you.

### Change

- Changed`Map.size/1` to `Kernel.map_size/1`
- Changed `System.system_time(:seconds)` to `System.system_time(:second)`
- Removed unused module attribute `@since`

Hope that this is not too trivial.