### PR TITLE
Adds oauth.v2.access method

### DIFF
--- a/lib/slack/web/docs/oauth.v2.access.json
+++ b/lib/slack/web/docs/oauth.v2.access.json
@@ -1,0 +1,38 @@
+{
+  "desc": "Exchanges a temporary OAuth verifier code for an access token.",
+
+  "args": {
+    "client_id": {
+      "required"  : true,
+      "example" : "4b39e9-752c4",
+      "desc"    : "Issued when you created your application."
+    },
+
+    "client_secret": {
+      "required"  : true,
+      "example" : "33fea0113f5b1",
+      "desc"    : "Issued when you created your application."
+    },
+
+    "code": {
+      "required"  : true,
+      "example" : "ccdaa72ad",
+      "desc"    : "The `code` param returned via the OAuth callback."
+    },
+
+    "redirect_uri": {
+      "required"  : false,
+      "example" : "http://example.com",
+      "desc"    : "This must match the originally submitted URI (if one was sent)."
+    }
+  },
+
+  "errors": {
+    "invalid_grant_type": "Value passed for grant_type was invalid.",
+    "invalid_client_id" : "Value passed for `client_id` was invalid.",
+    "bad_client_secret" : "Value passed for `client_secret` was invalid.",
+    "invalid_code"    : "Value passed for `code` was invalid.",
+    "bad_redirect_uri"  : "Value passed for `redirect_uri` did not match the `redirect_uri` in the original request.",
+    "oauth_authorization_url_mismatch": "The OAuth flow was initiated on an incorrect version of the authorization url. The flow must be initiated via /oauth/v2/authorize."
+  }
+}

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -13,13 +13,13 @@ defmodule Slack.Web.Documentation do
   ]
 
   def new(documentation, file_name) do
-    [module_name, function_name] =
-      String.replace(file_name, ".json", "")
-      |> String.split(".", parts: 2)
+    endpoint = String.replace(file_name, ".json", "")
+
+    {module_name, function_name} = parse_endpoint(endpoint)
 
     %__MODULE__{
       module: module_name,
-      endpoint: "#{module_name}.#{function_name}",
+      endpoint: endpoint,
       function: function_name |> Macro.underscore() |> String.to_atom(),
       desc: documentation["desc"],
       required_params: get_required_params(documentation),
@@ -108,5 +108,17 @@ defmodule Slack.Web.Documentation do
 
   defp get_params_with_required(_json, _required) do
     []
+  end
+
+  @spec parse_endpoint(String.t()) :: {String.t(), String.t()}
+  defp parse_endpoint(endpoint) do
+    {module_name, function_name} =
+      endpoint
+      |> String.graphemes()
+      |> Enum.reverse()
+      |> Enum.find_index(&(&1 == "."))
+      |> (&(String.split_at(endpoint, -&1))).()
+
+    {String.replace_suffix(module_name, ".", ""), function_name}
   end
 end

--- a/lib/slack/web/web.ex
+++ b/lib/slack/web/web.ex
@@ -24,8 +24,11 @@ end
 alias Slack.Web.Documentation
 
 Enum.each(Slack.Web.get_documentation(), fn {module_name, functions} ->
-  module_name = module_name |> Macro.camelize()
-  module = Module.concat(Slack.Web, module_name)
+  module =
+    module_name
+    |> String.split(".")
+    |> Enum.map(&Macro.camelize/1)
+    |> Enum.reduce(Slack.Web, &Module.concat(&2, &1))
 
   defmodule module do
     Enum.each(functions, fn doc ->

--- a/test/slack/web/documentation_test.exs
+++ b/test/slack/web/documentation_test.exs
@@ -8,4 +8,48 @@ defmodule Slack.Web.DocumentationTest do
     argument_value_keyword_list = Documentation.arguments_with_values(doc)
     assert argument_value_keyword_list === [text: {:text, [], nil}, channel: {:channel, [], nil}]
   end
+
+  describe "new/2" do
+    test "takes a documentation and filename, returns a module & function description" do
+      file_content = %{
+        "desc" => "Gets information about the current team.",
+        "args" => %{},
+        "errors" => %{}
+      }
+
+      doc = Documentation.new(file_content, "team.info.json")
+
+      assert doc.module == "team"
+      assert doc.endpoint == "team.info"
+      assert doc.function == :info
+      assert doc.desc == "Gets information about the current team."
+      assert doc.required_params == []
+      assert doc.optional_params == []
+      assert doc.errors == %{}
+      assert doc.raw == file_content
+
+      module_functions = Slack.Web.Team.__info__(:functions)
+
+      assert {:info, 0} in module_functions
+      assert {:info, 1} in module_functions
+    end
+
+    test "accepts versioned endpoints" do
+      file_content =
+        "#{__DIR__}/../../../lib/slack/web/docs/oauth.v2.access.json"
+        |> File.read!()
+        |> Poison.Parser.parse!(%{})
+
+      doc = Documentation.new(file_content, "oauth.v2.access.json")
+
+      assert doc.module == "oauth.v2"
+      assert doc.endpoint == "oauth.v2.access"
+      assert doc.function == :access
+
+      module_functions = Slack.Web.Oauth.V2.__info__(:functions)
+
+      assert {:access, 3} in module_functions
+      assert {:access, 4} in module_functions
+    end
+  end
 end


### PR DESCRIPTION
Docs: https://api.slack.com/methods/oauth.v2.access

This implies a breaking change: the current module generator is mapping
multi-level endpoint names to functions with [dashes in the name](https://hexdocs.pm/slack/Slack.Web.Files.html#comments/delete/3). For example,
`oauth.v2.access` becomes `Slack.Web.Oauth.v2/access/3`.

This, while valid, makes it very dificult to call the function and I believe was
unintended. This PR changes the generator so that the above endpoint becomes
`Slack.Web.Oauth.V2.access/3`.