### PR TITLE
Add `users.profile.get` and `users.profile.set` methods

### DIFF
--- a/lib/slack/web/docs/users.profile.get.json
+++ b/lib/slack/web/docs/users.profile.get.json
@@ -1,0 +1,22 @@
+{
+  "desc": "Retrieves a user's profile information.",
+
+  "args": {
+    "user": {
+      "type": "user",
+      "required": false,
+      "example": "W1234567890",
+      "desc": "User to retrieve profile info for"
+    },
+    "include_labels": {
+      "type": "boolean",
+      "required": false,
+      "example": true,
+      "desc": "Include labels for each ID in custom profile fields"
+    }
+  },
+
+  "errors": {
+    "user_not_found": "Value passed for `user` was invalid."
+  }
+}

--- a/lib/slack/web/docs/users.profile.set.json
+++ b/lib/slack/web/docs/users.profile.set.json
@@ -1,0 +1,36 @@
+{
+  "desc": "Set the profile information for a user.",
+
+  "args": {
+    "user": {
+      "type": "user",
+      "required": false,
+      "example": "W1234567890",
+      "desc": "User to retrieve profile info for"
+    },
+    "name": {
+      "required": false,
+      "example": "first_name",
+      "desc": "Name of a single key to set. Usable only if `profile` is not passed."
+    },
+    "value": {
+      "required": false,
+      "example": "John",
+      "desc": "Value to set a single key to. Usable only if `profile` is not passed."
+    },
+    "profile": {
+      "required": false,
+      "example": "`{ first_name: \"John\", ... }`",
+      "desc": "Collection of key:value pairs presented as a URL-encoded JSON hash. At most 50 fields may be set. Each field name is limited to 255 characters."
+    }
+  },
+
+  "errors": {
+    "reserved_name": "First or last name are reserved.",
+    "invalid_profile": "Profile object passed in is not valid JSON (make sure it is URL encoded!).",
+    "profile_set_failed": "Failed to set user profile.",
+    "not_admin": "Only admins can update the profile of another user. Some fields, like email may only be updated by an admin.",
+    "not_app_admin": "Only team owners and selected members can update the profile of a bot user.",
+    "cannot_update_admin_user": "Only a primary owner can update the profile of an admin."
+  }
+}


### PR DESCRIPTION
Set: https://api.slack.com/methods/users.profile.set
Get: https://api.slack.com/methods/users.profile.get

Should probably be merged after #209 since it also generates slashed function names by default.