### PR TITLE
admin.apps API Methods

### DIFF
--- a/lib/slack/web/docs/admin.apps.approve.json
+++ b/lib/slack/web/docs/admin.apps.approve.json
@@ -1,0 +1,67 @@
+{
+  "desc": "Approve an app for installation on a workspace.",
+
+  "args": {
+    "token": {
+      "required"  : true,
+      "example" : "xxxx-xxxxxxxxx-xxxx",
+      "desc"    : "Authentication token bearing required scopes."
+    },
+    "app_id": {
+      "required"  : false,
+      "example" : "A12345",
+      "desc"    : "The id of the app to approve. Required if `request_id` is missing."
+    },
+    "request_id": {
+      "required"  : false,
+      "example" : "Ar12345",
+      "desc"    : "The id of the request to approve. Required if `app_id` is missing."
+    },
+    "team_id": {
+      "required"  : false,
+      "example" : "A12345",
+      "desc"    : "The id of the team to approve. Required if your Enterprise Grid org contains more than one workspace."
+    }
+  },
+
+  "response": {
+    "ok": true
+  },
+
+  "errors": {
+    "invalid_request_id" : "The `request_id` passed was invalid.",
+    "invalid_app_id" : "The `app_id` passed was invalid.",
+    "request_id_required_for_custom_integrations" : "A `request_id` is required for custom integrations.",
+    "feature_not_enabled" : "Returned when the Admin APIs feature is not enabled for this team.",
+    "not_an_admin" : "This method is only accessible by org owners and admins.",
+    "request_id_or_app_id_is_required" : "Must include a `request_id` or `app_id`.",
+    "too_many_ids_provided" : "Please provide only `app_id` OR `request_id`.",
+    "too_many_teams_provided" : "Please provide only `team_id` OR `enterprise_id`.",
+    "request_already_resolved" : "The app request has already been resolved.",
+    "team_not_found" : "Returned when team id is not found.",
+    "app_management_app_not_installed_on_org" : "The app management app must be installed on the org.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+    "account_inactive": "Authentication token is for a deleted user or workspace.",
+    "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+    "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+    "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+    "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+    "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+    "is_bot": "This method cannot be called by a bot user.",
+    "invalid_arguments": "The method was called with invalid arguments.",
+    "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+    "invalid_charset": "The method was called via a `POST` request, but the `charset` specified in the `Content-Type` header was invalid. Valid charset names are: `utf-8` `iso-8859-1`.",
+    "invalid_form_data": "The method was called via a `POST` request with `Content-Type` `application/x-www-form-urlencoded` or `multipart/form-data`, but the form data was either missing or syntactically invalid.",
+    "invalid_post_type": "The method was called via a `POST` request, but the specified `Content-Type` was invalid. Valid types are: `application/json` `application/x-www-form-urlencoded` `multipart/form-data` `text/plain`.",
+    "missing_post_type": "The method was called via a `POST` request and included a data payload, but the request did not include a `Content-Type` header.",
+    "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+    "request_timeout": "The method was called via a `POST` request, but the `POST` data was either missing or truncated.",
+    "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised."
+  },
+
+  "warnings": {
+    "missing_charset": "The method was called via a `POST` request, and recommended practice for the specified `Content-Type` is to include a `charset` parameter. However, no `charset` was present. Specifically, non-form-data content types (e.g. `text/plain`) are the ones for which `charset` is recommended.",
+    "superfluous_charset": "The method was called via a `POST` request, and the specified `Content-Type` is not defined to understand the `charset` parameter. However, `charset` was in fact present. Specifically, form-data content types (e.g. `multipart/form-data`) are the ones for which `charset` is superfluous."
+  }
+}

--- a/lib/slack/web/docs/admin.apps.restrict.json
+++ b/lib/slack/web/docs/admin.apps.restrict.json
@@ -1,0 +1,67 @@
+{
+  "desc": "Restrict an app for installation on a workspace.",
+
+  "args": {
+    "token": {
+      "required"  : true,
+      "example" : "xxxx-xxxxxxxxx-xxxx",
+      "desc"    : "Authentication token bearing required scopes."
+    },
+    "app_id": {
+      "required"  : false,
+      "example" : "A12345",
+      "desc"    : "The id of the app to restrict. Required if `request_id` is missing."
+    },
+    "request_id": {
+      "required"  : false,
+      "example" : "Ar12345",
+      "desc"    : "The id of the request to restrict. Required if `app_id` is missing."
+    },
+    "team_id": {
+      "required"  : false,
+      "example" : "A12345",
+      "desc"    : "The id of the team to restrict. Required if your Enterprise Grid org contains more than one workspace."
+    }
+  },
+
+  "response": {
+    "ok": true
+  },
+
+  "errors": {
+    "invalid_request_id" : "The `request_id` passed was invalid.",
+    "invalid_app_id" : "The `app_id` passed was invalid.",
+    "request_id_required_for_custom_integrations" : "A `request_id` is required for custom integrations.",
+    "feature_not_enabled" : "Returned when the Admin APIs feature is not enabled for this team.",
+    "not_an_admin" : "This method is only accessible by org owners and admins.",
+    "request_id_or_app_id_is_required" : "Must include a `request_id` or `app_id`.",
+    "too_many_ids_provided" : "Please provide only `app_id` OR `request_id`.",
+    "too_many_teams_provided" : "Please provide only `team_id` OR `enterprise_id`.",
+    "request_already_resolved" : "The app request has already been resolved.",
+    "team_not_found" : "Returned when team id is not found.",
+    "app_management_app_not_installed_on_org" : "The app management app must be installed on the org.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+    "account_inactive": "Authentication token is for a deleted user or workspace.",
+    "token_revoked": "Authentication token is for a deleted user or workspace or the app has been removed.",
+    "no_permission": "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+    "org_login_required": "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+    "ekm_access_denied": "Administrators have suspended the ability to post a message.",
+    "missing_scope": "The token used is not granted the specific scope permissions required to complete this request.",
+    "is_bot": "This method cannot be called by a bot user.",
+    "invalid_arguments": "The method was called with invalid arguments.",
+    "invalid_arg_name": "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+    "invalid_charset": "The method was called via a `POST` request, but the `charset` specified in the `Content-Type` header was invalid. Valid charset names are: `utf-8` `iso-8859-1`.",
+    "invalid_form_data": "The method was called via a `POST` request with `Content-Type` `application/x-www-form-urlencoded` or `multipart/form-data`, but the form data was either missing or syntactically invalid.",
+    "invalid_post_type": "The method was called via a `POST` request, but the specified `Content-Type` was invalid. Valid types are: `application/json` `application/x-www-form-urlencoded` `multipart/form-data` `text/plain`.",
+    "missing_post_type": "The method was called via a `POST` request and included a data payload, but the request did not include a `Content-Type` header.",
+    "team_added_to_org": "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+    "request_timeout": "The method was called via a `POST` request, but the `POST` data was either missing or truncated.",
+    "fatal_error": "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised."
+  },
+
+  "warnings": {
+    "missing_charset": "The method was called via a `POST` request, and recommended practice for the specified `Content-Type` is to include a `charset` parameter. However, no `charset` was present. Specifically, non-form-data content types (e.g. `text/plain`) are the ones for which `charset` is recommended.",
+    "superfluous_charset": "The method was called via a `POST` request, and the specified `Content-Type` is not defined to understand the `charset` parameter. However, `charset` was in fact present. Specifically, form-data content types (e.g. `multipart/form-data`) are the ones for which `charset` is superfluous."
+  }
+}


### PR DESCRIPTION
Adds the `admin.apps` methods to the documentation store:

* https://api.slack.com/methods/admin.apps.approve
* https://api.slack.com/methods/admin.apps.restrict

Note that I added in 2 additional fields (not yet used):

* `response` - providing sample output for what you would expect to get back from the API
* `warnings` - separate issues from `errors` that do not block a successful return of the request

If you're okay with this format, I'll add in an additional PR to the `documentation.ex` file to include these 2 new fields and parse them properly.

**Note that the purpose of this PR is to illustrate an updated way of handling the API methods with additional fields. Once this is approved I'd like to know if it's okay to update the remaining methods since many of them are deprecated, incomplete, or out-of-date.**