### PR TITLE
must set ex_doc to 0.18 for elixir 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ def application do
 end
 
 def deps do
-  [{:slack, "~> 0.21.1"}]
+  [{:slack, "~> 0.21.2"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Slack.Mixfile do
       {:httpoison, "~> 1.2"},
       {:websocket_client, "~> 1.2.4"},
       {:poison, "~> 4.0"},
-      {:ex_doc, "~> 0.19", only: :dev},
+      {:ex_doc, "~> 0.18", only: :dev},
       {:credo, "~> 0.5", only: [:dev, :test]},
       {:plug, "~> 1.6", only: :test},
       {:cowboy, "~> 1.0.0", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Slack.Mixfile do
   def project do
     [
       app: :slack,
-      version: "0.21.1",
+      version: "0.21.2",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Slack",


### PR DESCRIPTION
Per `hex.publish`:

`ExDoc 0.19+ requires Elixir v1.7 and later. For earlier Elixir versions, make sure to depend on {:ex_doc, "~> 0.18.0"}`