### PR TITLE
Add missing blocks optional argument to chat endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ def application do
 end
 
 def deps do
-  [{:slack, "~> 0.23.4"}]
+  [{:slack, "~> 0.23.5"}]
 end
 ```
 

--- a/lib/slack/web/docs/chat.postEphemeral.json
+++ b/lib/slack/web/docs/chat.postEphemeral.json
@@ -12,7 +12,7 @@
 			"example"	: "Hello world",
 			"desc"		: "Text of the message to send. See below for an explanation of [formatting](#formatting)."
 		},
-    "user": {
+                "user": {
 			"type"		: "user",
 			"required"	: true,
 			"desc"		: "`id` of the user who will receive the ephemeral message. The user should be in the channel specified by the `channel` argument."
@@ -33,6 +33,11 @@
 			"required"	: false,
 			"example"	: "true",
 			"desc"		: "Pass true to post the message as the authed user, instead of as a bot. Defaults to false. See [authorship](#authorship) below."
+		},
+                "blocks": {
+                        "required"      : false,
+			"example"	: "[{\"type\": \"section\", \"text\": {\"type\": \"plain_text\", \"text\": \"Hello world\"}}]",
+			"desc"		: "A JSON-based array of structured blocks, presented as a URL-encoded string"
 		}
 	},
 

--- a/lib/slack/web/docs/chat.postMessage.json
+++ b/lib/slack/web/docs/chat.postMessage.json
@@ -24,6 +24,11 @@
 			"example"	: "[{\"pretext\": \"pre-hello\", \"text\": \"text-world\"}]",
 			"desc"		: "Structured message attachments."
 		},
+                "blocks": {
+                        "required"      : false,
+			"example"	: "[{\"type\": \"section\", \"text\": {\"type\": \"plain_text\", \"text\": \"Hello world\"}}]",
+			"desc"		: "A JSON-based array of structured blocks, presented as a URL-encoded string"
+		},
 		"unfurl_links": {
 			"example"	: "true",
 			"desc"		: "Pass true to enable unfurling of primarily text-based content."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Slack.Mixfile do
   def project do
     [
       app: :slack,
-      version: "0.23.4",
+      version: "0.23.5",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Slack",


### PR DESCRIPTION
Closes #225 

Turns out the blocks optional argument was missing from 2 chat methods

https://api.slack.com/methods/chat.postMessage
https://api.slack.com/methods/chat.postEphemeral