### PR TITLE
Add optional `thread_ts` param to chat.postMessage

### DIFF
--- a/lib/slack/web/docs/chat.postMessage.json
+++ b/lib/slack/web/docs/chat.postMessage.json
@@ -29,6 +29,11 @@
 			"example"	: "[{\"type\": \"section\", \"text\": {\"type\": \"plain_text\", \"text\": \"Hello world\"}}]",
 			"desc"		: "A JSON-based array of structured blocks, presented as a URL-encoded string"
 		},
+		"thread_ts": {
+                        "required"      : false,
+			"example"	: "1234567890.123456",
+			"desc"		: "Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead."
+		},
 		"unfurl_links": {
 			"example"	: "true",
 			"desc"		: "Pass true to enable unfurling of primarily text-based content."


### PR DESCRIPTION
https://api.slack.com/methods/chat.postMessage#arg_thread_ts `thread_ts` is a timestamp which identifies a message thread. If `thread_ts` is specified in chat.postMessage, the message is posted as a reply to the thread

Based on the the readme, I think that adding this json is all that is necessary to add this to the client, do I have that right?