### PR TITLE
Adapt to Slack API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,23 @@ The newest version of the Slack client introduces breaking changes with regards 
 
 ### Make additional calls to the Slack API to fetch bots, channels, groups, users, and IMs
 
-Wherever you grab the passed in `slack` state, add in additional calls to populate these lists:
+Wherever you grab the passed in `slack` state, add in additional calls to populate these lists.
+
+For example, to initialize the bot with the list of channels, fetch them in your `handle_connect` callback:
 
 ```elixir
-slack
-|> Map.put(:bots, Slack.Web.Bots.info(%{token: token}) |> Map.get("bot"))
-|> Map.put(:channels, Slack.Web.Channels.list(%{token: token}) |> Map.get("channels"))
-|> Map.put(:groups, Slack.Web.Groups.list(%{token: token}) |> Map.get("groups"))
-|> Map.put(:ims, Slack.Web.Im.list(%{token: token}) |> Map.get("ims"))
-|> Map.put(:users, Slack.Web.Users.list(%{token: token}) |> Map.get("members"))
+def handle_connect(slack, state) do
+  channels =
+    Slack.Web.Channels.list(%{token: slack.token})
+    |> Map.get(:channels)
+    |> Map.new(&{&1.id, &1})
+
+  slack =
+    slack
+    |> Map.put(:channels, channels)
+
+  {:ok, {slack, state}}
+end
 ```
 
 ## RTM (Bot) Usage

--- a/lib/slack/bot.ex
+++ b/lib/slack/bot.ex
@@ -99,8 +99,16 @@ defmodule Slack.Bot do
         _websocket_request,
         %{slack: slack, process_state: process_state, bot_handler: bot_handler} = state
       ) do
-    {:ok, new_process_state} = bot_handler.handle_connect(slack, process_state)
-    {:ok, %{state | process_state: new_process_state}}
+    state =
+      case bot_handler.handle_connect(slack, process_state) do
+        {:ok, {slack, new_process_state}} ->
+          %{state | slack: slack, process_state: new_process_state}
+
+        {:ok, new_process_state} ->
+          %{state | process_state: new_process_state}
+      end
+
+    {:ok, state}
   end
 
   @doc false

--- a/lib/slack/rtm.ex
+++ b/lib/slack/rtm.ex
@@ -42,6 +42,6 @@ defmodule Slack.Rtm do
 
   defp slack_url(token) do
     Application.get_env(:slack, :url, "https://slack.com") <>
-      "/api/rtm.start?token=#{token}&batch_presence_aware=true&presence_sub=true"
+      "/api/rtm.connect?token=#{token}&batch_presence_aware=true&presence_sub=true"
   end
 end

--- a/lib/slack/web/default_client.ex
+++ b/lib/slack/web/default_client.ex
@@ -22,7 +22,7 @@ defmodule Slack.Web.DefaultClient do
     url
     |> HTTPoison.post!(body, [], opts())
     |> Map.fetch!(:body)
-    |> Jason.decode!(%{})
+    |> Jason.decode!(keys: :atoms)
   end
 
   defp opts do

--- a/test/support/fake_slack/router.ex
+++ b/test/support/fake_slack/router.ex
@@ -27,4 +27,27 @@ defmodule Slack.FakeSlack.Router do
 
     send_resp(conn, 200, response)
   end
+
+  get "/api/rtm.connect" do
+    conn = fetch_query_params(conn)
+
+    pid = Application.get_env(:slack, :test_pid)
+    send(pid, {:token, conn.query_params["token"]})
+
+    response = ~S(
+      {
+        "ok": true,
+        "url": "ws://localhost:51345/ws",
+        "self": { "id": "U0123abcd", "name": "bot" },
+        "team": { "id": "T4567abcd", "name": "Example Team" },
+        "bots": [{ "id": "U0123abcd", "name": "bot" }],
+        "channels": [],
+        "groups": [],
+        "users": [],
+        "ims": []
+      }
+    )
+
+    send_resp(conn, 200, response)
+  end
 end


### PR DESCRIPTION
This PR makes a few changes to adapt to Slack API changes...

* It extends the `handle_connect` callback to enable initializing both the `slack` and `process_state`
* Connect via the `rtm.connect` instead of `rtm.start` API
* The HTTP client is set to `:atom` keys since that's what everything inside this library already expects

Some docs changes are likely in order, and can be added...

fixes #233 