### PR TITLE
Fix channel_joined access to channel.members

### DIFF
--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -45,7 +45,7 @@ defmodule Slack.State do
 
   def update(%{type: "channel_joined", channel: channel}, slack) do
     slack
-    |> put_in([:channels, channel.id, :members], channel.members)
+    |> put_in([:channels, channel.id], channel)
     |> put_in([:channels, channel.id, :is_member], true)
   end
 


### PR DESCRIPTION
# Problem
When listening on `channel_joined` event, the code crashes before even getting to the method on [`Slack.State` ](https://github.com/BlakeWilliams/Elixir-Slack/compare/master...ashkan18:fix-channel_joined?expand=1#diff-0b063e7ff16e55ed110f157ec1ae56f5e4fbea4399e6d1d2969508fa3e495a15L48) when trying to access `channel.members`.

```
20:49:31.040 [error] ** Websocket client Slack.Bot terminating in :websocket_handle/3
   for the reason :error:{:badkey, :members,
```

# Cause
Looking at what `channel` is at that point, there is no `member` attribute:
```elixir
%{
  reated: 1605533620,
  creator: "***",
  id: "***",
  is_archived: false,
  is_channel: true,
  is_ext_shared: false,
  is_frozen: false,
  is_general: false,
  is_group: false,
  is_im: false,
  is_member: true,
  is_mpim: false,
  is_org_shared: false,
  is_pending_ext_shared: false,
  is_private: false,
  is_shared: false,
  last_read: "1605664021.022400",
  latest: %{subtype: "channel_leave",
  text: "<@"***"> has left the channel",
  ts: ""***",",
  type: "message",
  user: "***"},
  name: "fikabot-support",
  name_normalized: "fikabot-support",
  parent_conversation: nil,
  pending_connected_team_ids: [],
  pending_shared: [],
  previous_names: [],
  priority: 0,
  purpose: %{creator: "***",
  last_set: 1605533621,
  value: "Join if you have questions about fikabot or you’d like to contribute"},
  shared_team_ids: ["***"],
  topic: %{creator: "",
  last_set: 0,
  value: ""},
  unlinked: 0,
  unread_count: 0,
  unread_count_display: 0
}
```

# Possible Solution
Ended up taking `members` out and also since this bot just joined the channel, added `channel` before setting `is_member` to `true`.
