### PR TITLE
Fix compilation warning on Elixir 1.11

### DIFF
--- a/lib/slack/lookups.ex
+++ b/lib/slack/lookups.ex
@@ -86,13 +86,14 @@ defmodule Slack.Lookups do
   @doc ~S"""
   Turns a Slack channel ID (`"C…"`) into a string in the format "#CHANNEL_NAME".
   """
+  def lookup_channel_name(channel_id, slack)
+
+  # Slack channel ID's (`"C…"`)
   def lookup_channel_name(channel_id = "C" <> _id, slack) do
     "#" <> slack.channels[channel_id].name
   end
 
-  @doc ~S"""
-  Turns a Slack private channel ID (`"G…"`) into a string in the format "#CHANNEL_NAME".
-  """
+  # Private channel ID's (`"G…"`)
   def lookup_channel_name(channel_id = "G" <> _id, slack) do
     "#" <> slack.groups[channel_id].name
   end


### PR DESCRIPTION
Here's an example of the warning:
```
==> slack
Compiling 10 files (.ex)
warning: redefining @doc attribute previously set at line 88.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head:

    @doc """
    new docs
    """
    def lookup_channel_name(...)

  lib/slack/lookups.ex:95: Slack.Lookups.lookup_channel_name/2

Compilation failed due to warnings while using the --warnings-as-errors option
```

On previous versions the initial `@doc` was silently ignored:
```
iex(1)> h Slack.Lookups.lookup_channel_name

                   def lookup_channel_name(channel_id, slack)

Turns a Slack private channel ID ("G…") into a string in the format
"#CHANNEL_NAME".
```

This change is backwards compatible with older elixir versions.