### PR TITLE
Add Conversations.kick API method

### DIFF
--- a/lib/slack/web/docs/conversations.kick.json
+++ b/lib/slack/web/docs/conversations.kick.json
@@ -1,0 +1,58 @@
+{
+	"desc": "Removes a user from a conversation.",
+
+	"args": {
+		"channel": {
+			"type"		: "channel",
+			"required"	: true,
+			"desc"		: "Conversation to remove user from."
+		},
+		"user": {
+			"type"		: "user",
+			"required"	: true,
+			"desc"		: "User to remove from conversation."
+		}
+	},
+
+	"errors": {
+        "channel_not_found"	: "Value passed for channel was invalid.",
+        "user_not_found"	: "Value passed for user was invalid.",
+        "cant_kick_self"	: "Authenticated user can't kick themselves from a channel.",
+        "not_in_channel"	: "User was not in the channel.",
+        "cant_kick_from_general"	: "User cannot be removed from #general.",
+        "method_not_supported_for_channel_type"	: "This type of conversation cannot be used with this method.",
+        "missing_scope"	: "The token used is not granted the specific scope permissions required to complete this request.",
+        "restricted_action"	: "A team preference prevents the authenticated user from kicking.",
+        "not_authed"	: "No authentication token provided.",
+        "invalid_auth"	: "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request.",
+        "account_inactive"	: "Authentication token is for a deleted user or workspace.",
+        "token_revoked"	: "Authentication token is for a deleted user or workspace or the app has been removed.",
+        "no_permission"	: "The workspace token used in this request does not have the permissions necessary to complete the request. Make sure your app is a member of the conversation it's attempting to post a message to.",
+        "org_login_required"	: "The workspace is undergoing an enterprise migration and will not be available until migration is complete.",
+        "ekm_access_denied"	: "Administrators have suspended the ability to post a message.",
+        "not_allowed_token_type"	: "The token type used in this request is not allowed.",
+        "method_deprecated"	: "The method has been deprecated.",
+        "deprecated_endpoint"	: "The endpoint has been deprecated.",
+        "two_factor_setup_required"	: "Two factor setup is required.",
+        "enterprise_is_restricted"	: "The method cannot be called from an Enterprise.",
+        "is_bot"	: "This method cannot be called by a bot user.",
+        "user_is_restricted"	: "This method cannot be called by a restricted user or single channel guest.",
+        "team_access_not_granted"	: "The token used is not granted the specific workspace access required to complete this request.",
+        "invalid_arguments"	: "The method was either called with invalid arguments or some detail about the arguments passed are invalid, which is more likely when using complex arguments like blocks or attachments.",
+        "invalid_arg_name"	: "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _. If you get this error, it is typically an indication that you have made a very malformed API call.",
+        "invalid_array_arg"	: "The method was passed an array as an argument. Please only input valid strings.",
+        "invalid_charset"	: "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1.",
+        "invalid_form_data"	: "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid.",
+        "invalid_post_type"	: "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/json application/x-www-form-urlencoded multipart/form-data text/plain.",
+        "missing_post_type"	: "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
+        "team_added_to_org"	: "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
+        "ratelimited"	: "The request has been ratelimited. Refer to the Retry-After header for when to retry the request.",
+        "accesslimited"	: "Access to this method is limited on the current network",
+        "request_timeout"	: "The method was called via a POST request, but the POST data was either missing or truncated.",
+        "service_unavailable"	: "The service is temporarily unavailable",
+        "fatal_error"	: "The server could not complete your operation(s) without encountering a catastrophic error. It's possible some aspect of the operation succeeded before the error was raised.",
+        "internal_error"	: "The server could not complete your operation(s) without encountering an error, likely due to a transient issue on our end. It's possible some aspect of the operation succeeded before the error was raised."
+	}
+}
+
+


### PR DESCRIPTION
Adding the new Conversations kick API method to docs to be included in client. This was missing from the original docs which create the client API methods. Since the Channels.kick method has been deprecated this is now the only alternative.