### PR TITLE
text no longer required param for chat.postMessage API

### DIFF
--- a/lib/slack/web/docs/chat.postMessage.json
+++ b/lib/slack/web/docs/chat.postMessage.json
@@ -8,7 +8,7 @@
 			"desc"		: "Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name. See [below](#channels) for more details."
 		},
 		"text": {
-			"required"	: true,
+			"required"	: false,
 			"example"	: "Hello world",
 			"desc"		: "Text of the message to send. See below for an explanation of [formatting](#formatting)."
 		},


### PR DESCRIPTION
Per the docs, `text` is not a required field for `chat.postMessage`: https://api.slack.com/methods/chat.postMessage