### PR TITLE
Update GitHub actions workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,25 +2,65 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        otp: ['21.0', '22.0']
-        elixir: ['1.7.2', '1.10.1']
+        elixir: ['1.13', '1.12', '1.11', '1.10']
+        otp: ['24.x', '23.x', '22.x']
+        exclude:
+          - elixir: '1.10'
+            otp: '24.x'
+          - elixir: '1.13'
+            otp: '22.x'
+        include:
+          - lint: lint
+            elixir: '1.13'
+            otp: '24.x'
+          - elixir: '1.13'
+            otp: '25.x'
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup elixir
-      uses: actions/setup-elixir@v1
-      with:
-        elixir-version: ${{matrix.elixir}} # Define the elixir version [required]
-        otp-version: ${{matrix.otp}} # Define the OTP version [required]
-    - name: Install Dependencies
-      run: mix deps.get
-    - name: Run Tests
-      run: mix test
+      - uses: actions/checkout@v3
+
+      - name: Setup BEAM
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v2
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}
+            ${{ runner.os }}-mix-${{ matrix.otp }}-
+            ${{ runner.os }}-mix-
+
+      - name: Install Dependencies
+        if: steps.mix-cache.outputs.cache-hit != 'true'
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix deps.compile
+
+      - run: mix format --check-formatted
+        if: matrix.lint
+
+      - run: mix credo
+        if: matrix.lint
+
+      - name: Run Tests
+        run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,17 +14,10 @@ jobs:
       matrix:
         elixir: ['1.13', '1.12', '1.11', '1.10']
         otp: ['24.x', '23.x', '22.x']
-        exclude:
-          - elixir: '1.10'
-            otp: '24.x'
-          - elixir: '1.13'
-            otp: '22.x'
         include:
           - lint: lint
             elixir: '1.13'
             otp: '24.x'
-          - elixir: '1.13'
-            otp: '25.x'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -52,8 +52,5 @@ jobs:
       - run: mix format --check-formatted
         if: matrix.lint
 
-      - run: mix credo
-        if: matrix.lint
-
       - name: Run Tests
         run: mix test

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -93,13 +93,11 @@ defmodule Slack do
         }
       end
 
-      defoverridable [
-        handle_connect: 2,
-        handle_event: 3,
-        handle_close: 3,
-        handle_info: 3,
-        child_spec: 1
-      ]
+      defoverridable handle_connect: 2,
+                     handle_event: 3,
+                     handle_close: 3,
+                     handle_info: 3,
+                     child_spec: 1
     end
   end
 end

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -56,7 +56,6 @@ defmodule Slack.State do
     put_in(slack, [:groups, channel.id], channel)
   end
 
-
   def update(%{type: "channel_left", channel: channel_id}, slack) do
     put_in(slack, [:channels, channel_id, :is_member], false)
   end
@@ -81,7 +80,13 @@ defmodule Slack.State do
     end
 
     def update(
-          %{type: "message", subtype: unquote(type <> "_topic"), channel: channel, user: user, topic: topic},
+          %{
+            type: "message",
+            subtype: unquote(type <> "_topic"),
+            channel: channel,
+            user: user,
+            topic: topic
+          },
           slack
         ) do
       put_in(slack, [unquote(plural_atom), safe_map_getter(channel), :topic], %{
@@ -95,14 +100,22 @@ defmodule Slack.State do
           %{type: "message", subtype: unquote(type <> "_join"), channel: channel, user: user},
           slack
         ) do
-      update_in(slack, [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)], &Enum.uniq([user | &1]))
+      update_in(
+        slack,
+        [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)],
+        &Enum.uniq([user | &1])
+      )
     end
 
     def update(
           %{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user},
           slack
         ) do
-      update_in(slack, [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)], &(&1 -- [user]))
+      update_in(
+        slack,
+        [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)],
+        &(&1 -- [user])
+      )
     end
   end)
 

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -117,7 +117,7 @@ defmodule Slack.Web.Documentation do
       |> String.graphemes()
       |> Enum.reverse()
       |> Enum.find_index(&(&1 == "."))
-      |> (&(String.split_at(endpoint, -&1))).()
+      |> (&String.split_at(endpoint, -&1)).()
 
     {String.replace_suffix(module_name, ".", ""), function_name}
   end


### PR DESCRIPTION
## Description

- Updates the matrix table to more modern versions
- Updates the setup elixir action to a maintained version by Erlang (see: https://github.com/actions/setup-elixir#setup-elixir)
- Added dependency caching as it can speed up CI

For now I left `mix credo` out of it as it was not in the current pipeline and there's probably a lot to fix. Let's do this in future PRs. There's a lot of deprecated methods across versions and there's probably a discussion to be had over which OTP + Elixir versions we should support.

Note: This CI pipeline is inspired by the setup of: https://github.com/swoosh/swoosh