### PR TITLE
Mix format remaining unformatted files

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/slack.ex
+++ b/lib/slack.ex
@@ -93,13 +93,11 @@ defmodule Slack do
         }
       end
 
-      defoverridable [
-        handle_connect: 2,
-        handle_event: 3,
-        handle_close: 3,
-        handle_info: 3,
-        child_spec: 1
-      ]
+      defoverridable handle_connect: 2,
+                     handle_event: 3,
+                     handle_close: 3,
+                     handle_info: 3,
+                     child_spec: 1
     end
   end
 end

--- a/lib/slack/state.ex
+++ b/lib/slack/state.ex
@@ -56,7 +56,6 @@ defmodule Slack.State do
     put_in(slack, [:groups, channel.id], channel)
   end
 
-
   def update(%{type: "channel_left", channel: channel_id}, slack) do
     put_in(slack, [:channels, channel_id, :is_member], false)
   end
@@ -81,7 +80,13 @@ defmodule Slack.State do
     end
 
     def update(
-          %{type: "message", subtype: unquote(type <> "_topic"), channel: channel, user: user, topic: topic},
+          %{
+            type: "message",
+            subtype: unquote(type <> "_topic"),
+            channel: channel,
+            user: user,
+            topic: topic
+          },
           slack
         ) do
       put_in(slack, [unquote(plural_atom), safe_map_getter(channel), :topic], %{
@@ -95,14 +100,22 @@ defmodule Slack.State do
           %{type: "message", subtype: unquote(type <> "_join"), channel: channel, user: user},
           slack
         ) do
-      update_in(slack, [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)], &Enum.uniq([user | &1]))
+      update_in(
+        slack,
+        [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)],
+        &Enum.uniq([user | &1])
+      )
     end
 
     def update(
           %{type: "message", subtype: unquote(type <> "_leave"), channel: channel, user: user},
           slack
         ) do
-      update_in(slack, [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)], &(&1 -- [user]))
+      update_in(
+        slack,
+        [unquote(plural_atom), safe_map_getter(channel), safe_list_getter(:members)],
+        &(&1 -- [user])
+      )
     end
   end)
 

--- a/lib/slack/web/documentation.ex
+++ b/lib/slack/web/documentation.ex
@@ -117,7 +117,7 @@ defmodule Slack.Web.Documentation do
       |> String.graphemes()
       |> Enum.reverse()
       |> Enum.find_index(&(&1 == "."))
-      |> (&(String.split_at(endpoint, -&1))).()
+      |> (&String.split_at(endpoint, -&1)).()
 
     {String.replace_suffix(module_name, ".", ""), function_name}
   end


### PR DESCRIPTION
> Related to: https://github.com/BlakeWilliams/Elixir-Slack/pull/253

## Description

- Runs the `mix format` command and updates all unformatted files.
- Updates the `config/config.exs` file to not use the deprecated `Mix.Config` module anymore (see: [`Mix.Config`](https://hexdocs.pm/mix/1.13.4/Mix.Config.html) and [`Config`](https://hexdocs.pm/elixir/1.13/Config.html))